### PR TITLE
feat: Validate stop_at_paths parents and TableConfig levels depth

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,11 +44,24 @@ impl Config {
     /// - Field `xml_path` must be a descendant of (or equal to) the parent table's `xml_path`,
     ///   unless the table's `xml_path` is `/` (root table, which allows any field path).
     /// - Scale/offset may only be used with Float32 and Float64 fields.
+    /// - `TableConfig::levels` must not exceed the number of non-root tables
+    ///   along the table's path (including itself). Over-specifying `levels`
+    ///   produces empty index columns that fail Arrow's length checks at
+    ///   finalization; under-specifying is allowed for singleton tables that
+    ///   don't want index columns.
     ///
     /// # Errors
     ///
     /// Returns an error if any of the above constraints are violated.
     pub fn validate(&self) -> Result<()> {
+        // Pre-compute segment slices once so the levels-depth check below
+        // doesn't re-parse every table's xml_path for every other table.
+        let table_segments: Vec<Vec<&str>> = self
+            .tables
+            .iter()
+            .map(|t| path_segments(&t.xml_path))
+            .collect();
+
         // --- Table-level checks ---
         let mut table_names = HashSet::with_capacity(self.tables.len());
         for table in &self.tables {
@@ -101,6 +114,37 @@ impl Config {
                 field.validate()?;
             }
         }
+
+        // --- Cross-table levels check ---
+        //
+        // Each time a row of table T is finalized, the parser emits one index
+        // value per non-root table currently on the builder stack — i.e. T
+        // itself plus every non-root table whose xml_path is a path-prefix of
+        // T's xml_path. If `levels.len()` exceeds this depth, the extra
+        // `index_builders` never receive values, and `RecordBatch::try_new`
+        // will fail on mismatched array lengths. Reject that case up front
+        // with a readable error instead.
+        for (i, table) in self.tables.iter().enumerate() {
+            let target = &table_segments[i];
+            let depth = self
+                .tables
+                .iter()
+                .zip(&table_segments)
+                .filter(|(t, _)| t.xml_path != "/")
+                .filter(|(_, segs)| is_path_prefix(segs, target))
+                .count();
+            if table.levels.len() > depth {
+                return Err(Error::InvalidConfig(format!(
+                    "Table '{}' has {} levels but its xml_path '{}' supports at most {} \
+                     (one per non-root ancestor table plus itself)",
+                    table.name,
+                    table.levels.len(),
+                    table.xml_path,
+                    depth,
+                )));
+            }
+        }
+
         Ok(())
     }
 
@@ -409,6 +453,24 @@ impl DType {
             DType::UInt64 => DataType::UInt64,
         }
     }
+}
+
+/// Splits an `xml_path` into non-empty segments, normalizing leading slashes
+/// and collapsing any double/trailing slashes. Matches the segmentation
+/// `PathRegistry::get_or_create_path` performs, so validation and registry
+/// lookups agree on what "depth" means.
+fn path_segments(path: &str) -> Vec<&str> {
+    path.trim_start_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Returns true if `prefix` is a path-prefix of `full` by segment equality.
+/// Uses segment-wise comparison so that `/a/bc` is not treated as a prefix of
+/// `/a/bcd/e`.
+fn is_path_prefix(prefix: &[&str], full: &[&str]) -> bool {
+    prefix.len() <= full.len() && full[..prefix.len()] == *prefix
 }
 
 /// Creates a `Config` struct from a YAML string literal.
@@ -878,6 +940,132 @@ mod tests {
             )],
         };
         assert!(config.validate().is_ok());
+    }
+
+    // --- Levels-depth validation tests ---
+
+    #[test]
+    fn test_levels_over_specified_rejected() {
+        // The table sits at /doc with no non-root ancestors, so depth = 1
+        // (self). Two levels means one extra index builder that would never
+        // receive values and would fail RecordBatch::try_new.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![TableConfig::new(
+                "items",
+                "/doc",
+                vec!["a".to_string(), "b".to_string()],
+                vec![
+                    FieldConfigBuilder::new("value", "/doc/item/value", DType::Int32)
+                        .build()
+                        .unwrap(),
+                ],
+            )],
+        };
+        let err = config.validate().unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig(_)));
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("items") && msg.contains("2 levels") && msg.contains("at most 1"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_levels_under_specified_accepted_for_singleton() {
+        // Singleton tables (no iteration) legitimately opt out of their
+        // self-index column by using levels: []. The parser handles this by
+        // emitting only the configured field columns.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![TableConfig::new(
+                "metadata",
+                "/root/metadata",
+                vec![],
+                vec![
+                    FieldConfigBuilder::new("version", "/root/metadata/version", DType::Utf8)
+                        .build()
+                        .unwrap(),
+                ],
+            )],
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_levels_match_full_nested_depth_accepted() {
+        // Four nested non-root tables; the innermost has levels for every
+        // ancestor plus itself.
+        let mk = |name: &str, path: &str, levels: &[&str]| {
+            TableConfig::new(
+                name,
+                path,
+                levels.iter().map(|s| (*s).to_string()).collect(),
+                vec![],
+            )
+        };
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![
+                mk("as", "/root", &["a"]),
+                mk("bs", "/root/a", &["a", "b"]),
+                mk("cs", "/root/a/b", &["a", "b", "c"]),
+                mk("ds", "/root/a/b/c", &["a", "b", "c", "d"]),
+            ],
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_root_table_with_nonempty_levels_rejected() {
+        // The root table "/" is explicitly skipped in the parser's
+        // parent-indices collection, so it can never receive any level index
+        // values. Any nonempty `levels` list is therefore unreachable.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![TableConfig::new(
+                "root",
+                "/",
+                vec!["a".to_string()],
+                vec![],
+            )],
+        };
+        let err = config.validate().unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig(_)));
+        let msg = format!("{err:?}");
+        assert!(msg.contains("root"), "unexpected error message: {msg}");
+    }
+
+    #[test]
+    fn test_levels_depth_uses_segment_equality_not_string_prefix() {
+        // String prefixing would treat `/a/bc` as a prefix of `/a/bcd`, but
+        // segment-wise prefixing (what the parser actually applies) does not.
+        // The inner table has only itself as a non-root prefix table.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![
+                TableConfig::new("outer", "/a/bc", vec!["outer".to_string()], vec![]),
+                TableConfig::new("inner", "/a/bcd", vec!["inner".to_string()], vec![]),
+            ],
+        };
+        assert!(config.validate().is_ok());
+
+        // Now over-specify: asking for 2 levels on the inner table should
+        // fail since `/a/bc` is not a segment-prefix of `/a/bcd`.
+        let bad = Config {
+            parser_options: Default::default(),
+            tables: vec![
+                TableConfig::new("outer", "/a/bc", vec!["outer".to_string()], vec![]),
+                TableConfig::new(
+                    "inner",
+                    "/a/bcd",
+                    vec!["outer".to_string(), "inner".to_string()],
+                    vec![],
+                ),
+            ],
+        };
+        let err = bad.validate().unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig(_)));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1023,12 +1023,7 @@ mod tests {
         // values. Any nonempty `levels` list is therefore unreachable.
         let config = Config {
             parser_options: Default::default(),
-            tables: vec![TableConfig::new(
-                "root",
-                "/",
-                vec!["a".to_string()],
-                vec![],
-            )],
+            tables: vec![TableConfig::new("root", "/", vec!["a".to_string()], vec![])],
         };
         let err = config.validate().unwrap_err();
         assert!(matches!(err, Error::InvalidConfig(_)));

--- a/src/path_registry.rs
+++ b/src/path_registry.rs
@@ -24,6 +24,7 @@
 use fxhash::FxHashMap;
 
 use crate::config::Config;
+use crate::errors::{Error, Result};
 
 /// A node ID in the path registry trie.
 ///
@@ -150,13 +151,54 @@ impl PathRegistry {
             registry.node_info[node_id_idx].has_attribute_children = has_attr_child;
         }
 
-        // Phase 4: register optional stop paths so the parser can resolve them
-        // without string lookups in the hot loop.
-        for stop_path in &config.parser_options.stop_at_paths {
-            registry.get_or_create_path(stop_path);
-        }
+        // Note: `stop_at_paths` are intentionally *not* registered here. They go
+        // through `register_stop_path` separately so typos can be rejected as
+        // `Error::InvalidConfig` rather than silently creating phantom nodes
+        // the parser would never encounter.
 
         registry
+    }
+
+    /// Registers an optional `stop_at_paths` entry in the trie.
+    ///
+    /// Stop paths are allowed to point at elements the user otherwise ignores
+    /// (e.g. stopping at `/root/summary` when only `/root/meta` is configured),
+    /// so we can't require them to already exist in full. But we *can* catch
+    /// obvious typos cheaply by requiring the parent path to be known from the
+    /// table/field registrations (Phases 1-3). A typo like `/root/sumary` where
+    /// `/root/sumary`'s parent `/root` is known still slips through — but a
+    /// typo like `/ruto/summary` where even the parent is unknown is flagged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidConfig` if the parent path of `path_str` is not
+    /// already in the registry.
+    pub fn register_stop_path(&mut self, path_str: &str) -> Result<PathNodeId> {
+        let segments: Vec<&str> = path_str
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // A stop path of "/" (no segments) targets the root, which always exists.
+        let Some((leaf, parent_segments)) = segments.split_last() else {
+            return Ok(PathNodeId::ROOT);
+        };
+
+        // Walk the parent path strictly against existing nodes.
+        let mut parent = PathNodeId::ROOT;
+        for (depth, part) in parent_segments.iter().enumerate() {
+            parent = self.get_child(parent, part.as_bytes()).ok_or_else(|| {
+                let unknown_prefix = format!("/{}", parent_segments[..=depth].join("/"));
+                Error::InvalidConfig(format!(
+                    "stop_at_paths entry '{path_str}' references unknown parent path \
+                     '{unknown_prefix}' — no table or field is configured under it"
+                ))
+            })?;
+        }
+
+        // Parent is known; create (or reuse) the leaf node.
+        Ok(self.get_or_create_child(parent, leaf.as_bytes()))
     }
 
     /// Gets or creates a path in the trie, returning its node ID.
@@ -176,23 +218,6 @@ impl PathRegistry {
         }
 
         current_node
-    }
-
-    /// Resolves a path string to an existing node ID without creating new nodes.
-    ///
-    /// Returns `None` if the path doesn't exist in the registry.
-    pub fn resolve_path(&self, path_str: &str) -> Option<PathNodeId> {
-        let mut current_node = PathNodeId::ROOT;
-
-        for part in path_str
-            .trim_start_matches('/')
-            .split('/')
-            .filter(|s| !s.is_empty())
-        {
-            current_node = self.get_child(current_node, part.as_bytes())?;
-        }
-
-        Some(current_node)
     }
 
     /// Gets or creates a child node for the given parent and name.

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -484,14 +484,19 @@ impl XmlToArrowConverter {
         config.validate()?;
 
         // Build path registry for efficient lookups
-        let registry = PathRegistry::from_config(config);
+        let mut registry = PathRegistry::from_config(config);
 
+        // Register every stop path, rejecting entries whose parent path is
+        // unknown. The lenient check still allows stopping at elements that
+        // aren't otherwise referenced in the config (e.g. stopping at a
+        // `<summary>` sibling of a configured table) while catching obvious
+        // typos where even the parent segment doesn't exist.
         let stop_node_ids = config
             .parser_options
             .stop_at_paths
             .iter()
-            .filter_map(|path| registry.resolve_path(path))
-            .collect::<Vec<_>>();
+            .map(|path| registry.register_stop_path(path))
+            .collect::<Result<Vec<_>>>()?;
 
         let mut table_builders = Vec::with_capacity(config.tables.len());
         for table_config in &config.tables {
@@ -4098,6 +4103,72 @@ mod tests {
         // Data should be empty (parsing stopped before it)
         let data = record_batches.get("data").unwrap();
         assert_eq!(data.num_rows(), 0);
+    }
+
+    #[test]
+    fn test_stop_at_paths_typo_parent_rejected() {
+        // `/ruto/something` is a typo — the parent `/ruto` is not configured
+        // anywhere, so the stop path can never trigger. We reject it at setup
+        // time rather than silently parsing the whole document.
+        let config = config_from_yaml!(
+            r#"
+            parser_options:
+                stop_at_paths:
+                    - /ruto/something
+            tables:
+                - name: items
+                  xml_path: /root/items
+                  levels: [item]
+                  fields:
+                    - name: value
+                      xml_path: /root/items/item/value
+                      data_type: Int32
+            "#
+        );
+
+        let xml = b"<root><items><item><value>1</value></item></items></root>";
+        let err = parse_xml_slice(xml, &config).unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig(_)));
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("/ruto/something") && msg.contains("/ruto"),
+            "expected error to mention the typo'd path and the unknown parent, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_stop_at_paths_known_parent_accepted_even_if_leaf_unreferenced() {
+        // `/root/summary` is not otherwise referenced in the config, but its
+        // parent `/root` is known (via the `/root/items/...` field), so the
+        // lenient check accepts it. The stop still fires when `<summary>`
+        // closes during parsing.
+        let xml = br#"
+        <root>
+            <items><item><value>1</value></item></items>
+            <summary><count>99</count></summary>
+            <tail><item><value>2</value></item></tail>
+        </root>
+        "#;
+
+        let config = config_from_yaml!(
+            r#"
+            parser_options:
+                stop_at_paths:
+                    - /root/summary
+            tables:
+                - name: items
+                  xml_path: /root/items
+                  levels: [item]
+                  fields:
+                    - name: value
+                      xml_path: /root/items/item/value
+                      data_type: Int32
+            "#
+        );
+
+        let batches = parse_xml_slice(xml, &config).unwrap();
+        let items = batches.get("items").unwrap();
+        assert_eq!(items.num_rows(), 1);
     }
 
     // =========================================================================


### PR DESCRIPTION
stop_at_paths entries no longer silently become phantom trie nodes when their parent path is unknown. PathRegistry drops Phase 4's create-on-demand and exposes register_stop_path, which requires the parent path to exist from tables/fields before creating the leaf. Typos like /ruto/something now fail with Error::InvalidConfig; legitimate stop paths with a known parent (e.g. /root/summary sibling of a configured /root/meta table) still work. Also removes the now-dead resolve_path helper.

Config::validate rejects configs where TableConfig::levels exceeds the table's hierarchy depth (non-root ancestor tables plus itself), which would otherwise cause RecordBatch::try_new to fail at finalization with mismatched array lengths. Shorter levels are still allowed so singleton tables can continue to opt out of index columns.