### PR TITLE
perf: add opt-in strip_namespaces to skip per-name prefix scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ parser_options:
   trim_text: <true|false>      # Trim whitespace from text nodes (default: false)
   stop_at_paths: [<xml_path>]  # Stop parsing after these closing tags (optional,
                                # useful for reading only a file header)
+  strip_namespaces: <bool>     # Strip ns: prefixes before matching (default: true).
+                               # Set false to match raw qualified names and skip
+                               # the per-name prefix scan (~4-7% faster); paths must
+                               # then spell out any prefix. Free for prefix-free XML.
 tables:
   - name: <table_name>         # Name of the resulting Arrow RecordBatch
     xml_path: <xml_path>       # Path to the element whose children are rows.

--- a/benches/parse_benchmark.rs
+++ b/benches/parse_benchmark.rs
@@ -104,6 +104,7 @@ parser_options:
   trim_text: false
   validate_closing_tags: false
   validate_attributes: false
+  strip_namespaces: false
 tables:
   - name: root
     xml_path: /
@@ -526,7 +527,7 @@ fn generate_wide_xml(num_records: usize, num_fields: usize) -> String {
 
 fn get_wide_config(num_fields: usize) -> Config {
     let mut yaml = String::from(
-        "parser_options:\n  trim_text: false\n  validate_closing_tags: false\ntables:\n  - name: records\n    xml_path: /root/records\n    levels:\n      - record\n    fields:\n",
+        "parser_options:\n  trim_text: false\n  validate_closing_tags: false\n  strip_namespaces: false\ntables:\n  - name: records\n    xml_path: /root/records\n    levels:\n      - record\n    fields:\n",
     );
     for field_idx in 0..num_fields {
         yaml.push_str(&format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,24 @@ pub struct ParserOptions {
     /// when the input is trusted to be well-formed.
     #[serde(default = "default_true")]
     pub validate_attributes: bool,
+    /// Whether to strip XML namespace prefixes from element and attribute
+    /// names before matching them against configured paths. Defaults to
+    /// `true` — `<ns:sensor>` matches a config path of `sensor`.
+    ///
+    /// Internally `true` resolves each name with quick-xml's `local_name()`,
+    /// which scans the name for a `:` separator on **every** element and
+    /// attribute. For documents that use no namespace prefixes (the common
+    /// case for the data XML this crate targets) that scan finds nothing and
+    /// is pure overhead — a measurable ~4–7% of total parse time. Setting
+    /// `false` uses the raw qualified name (`name()`) and skips the scan.
+    ///
+    /// The trade-off: with `false`, configured paths must spell out any
+    /// prefix exactly as it appears in the document (`ns:sensor`, not
+    /// `sensor`). For namespace-free input the two modes produce identical
+    /// results, so disabling is free; only disable when your input either
+    /// uses no prefixes or your config already encodes them.
+    #[serde(default = "default_true")]
+    pub strip_namespaces: bool,
 }
 
 impl Default for ParserOptions {
@@ -55,6 +73,7 @@ impl Default for ParserOptions {
             stop_at_paths: Vec::new(),
             validate_closing_tags: true,
             validate_attributes: true,
+            strip_namespaces: true,
         }
     }
 }
@@ -603,6 +622,35 @@ mod tests {
         assert!(
             !config.parser_options.trim_text,
             "trim_text should default to false"
+        );
+    }
+
+    #[test]
+    fn test_parser_options_strip_namespaces_defaults_to_true() {
+        let yaml_string = r#"
+            parser_options: {}
+            tables: []
+            "#;
+
+        let config: Config = yaml_serde::from_str(yaml_string).unwrap();
+        assert!(
+            config.parser_options.strip_namespaces,
+            "strip_namespaces should default to true"
+        );
+    }
+
+    #[test]
+    fn test_parser_options_strip_namespaces_set_explicitly() {
+        let yaml_string = r#"
+            parser_options:
+              strip_namespaces: false
+            tables: []
+            "#;
+
+        let config: Config = yaml_serde::from_str(yaml_string).unwrap();
+        assert!(
+            !config.parser_options.strip_namespaces,
+            "strip_namespaces should be false when explicitly set"
         );
     }
 

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -515,6 +515,11 @@ struct XmlToArrowConverter<'a> {
     /// (and its backing allocation). Cached here so `parse_attributes` reads
     /// a plain `bool` rather than re-deriving it from the config each call.
     validate_attributes: bool,
+    /// Mirror of `ParserOptions::strip_namespaces`. When `true`, element and
+    /// attribute names are resolved via `local_name()` (stripping any `ns:`
+    /// prefix); when `false`, the raw qualified `name()` is used, skipping the
+    /// per-name `:` scan. Cached here so the hot path reads a plain `bool`.
+    strip_namespaces: bool,
 }
 
 impl<'a> XmlToArrowConverter<'a> {
@@ -537,6 +542,7 @@ impl<'a> XmlToArrowConverter<'a> {
             registry: &parser.registry,
             parent_indices_buffer: Vec::new(),
             validate_attributes: config.parser_options.validate_attributes,
+            strip_namespaces: config.parser_options.strip_namespaces,
         }
     }
 
@@ -966,7 +972,15 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
 ) -> Result<LoopAction> {
     match event {
         Event::Start(e) => {
-            let name_bytes = e.local_name().into_inner();
+            // `strip_namespaces` (default) resolves the local name, dropping any
+            // `ns:` prefix; disabling it uses the raw qualified name and skips
+            // quick-xml's per-name `:` scan — identical output for prefix-free
+            // documents (see `ParserOptions::strip_namespaces`).
+            let name_bytes = if xml_to_arrow_converter.strip_namespaces {
+                e.local_name().into_inner()
+            } else {
+                e.name().into_inner()
+            };
 
             // Fused lookup: child resolution + node-info read in one pass.
             // The `&PathNodeInfo` borrow is dropped before any mutable use
@@ -994,7 +1008,15 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
             }
         }
         Event::Empty(e) => {
-            let name_bytes = e.local_name().into_inner();
+            // `strip_namespaces` (default) resolves the local name, dropping any
+            // `ns:` prefix; disabling it uses the raw qualified name and skips
+            // quick-xml's per-name `:` scan — identical output for prefix-free
+            // documents (see `ParserOptions::strip_namespaces`).
+            let name_bytes = if xml_to_arrow_converter.strip_namespaces {
+                e.local_name().into_inner()
+            } else {
+                e.name().into_inner()
+            };
 
             let (node_id_opt, table_index, has_attrs, is_table) =
                 match path_tracker.enter(name_bytes, xml_to_arrow_converter.registry) {
@@ -1167,9 +1189,16 @@ fn parse_attributes(
     if !xml_to_arrow_converter.validate_attributes {
         attributes.with_checks(false);
     }
+    // Hoisted out of the loop: same `:`-scan trade-off as element names, applied
+    // to each attribute key (see `ParserOptions::strip_namespaces`).
+    let strip_namespaces = xml_to_arrow_converter.strip_namespaces;
     for attribute in attributes {
         let attribute = attribute?;
-        let key = attribute.key.local_name().into_inner();
+        let key = if strip_namespaces {
+            attribute.key.local_name().into_inner()
+        } else {
+            attribute.key.into_inner()
+        };
 
         // Reuse buffer to avoid allocation: build "@key" as bytes
         attr_name_buffer.clear();
@@ -4972,5 +5001,103 @@ mod tests {
         let batch = record_batches.get("test").unwrap();
         assert_eq!(batch.num_rows(), 1);
         assert_array_values!(batch, "id", vec![42i32], Int32Array);
+    }
+
+    #[test]
+    fn test_strip_namespaces_false_prefix_free_matches_local_names() {
+        // For prefix-free input, disabling strip_namespaces is free: the raw
+        // name() and local_name() are byte-identical, so existing configs work
+        // unchanged. This is the common-case fast path.
+        let xml_content = r#"<data><item id="7"><value>42</value></item></data>"#;
+        let record_batches = parse(
+            xml_content,
+            r#"
+            parser_options:
+              strip_namespaces: false
+            tables:
+                - name: test
+                  xml_path: /data
+                  levels: [item]
+                  fields:
+                    - name: id
+                      xml_path: /data/item/@id
+                      data_type: Int32
+                    - name: value
+                      xml_path: /data/item/value
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("test").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_array_values!(batch, "id", vec![7i32], Int32Array);
+        assert_array_values!(batch, "value", vec![42i32], Int32Array);
+    }
+
+    #[test]
+    fn test_strip_namespaces_false_matches_qualified_names() {
+        // With strip_namespaces=false, configured paths must spell out the
+        // prefix exactly as it appears in the document — for both elements
+        // (levels + field paths) and attributes.
+        let xml_content = r#"<data xmlns:ns="http://example.com"><ns:item ns:id="7"><ns:value>42</ns:value></ns:item></data>"#;
+        let record_batches = parse(
+            xml_content,
+            r#"
+            parser_options:
+              strip_namespaces: false
+            tables:
+                - name: test
+                  xml_path: /data
+                  levels: ["ns:item"]
+                  fields:
+                    - name: id
+                      xml_path: /data/ns:item/@ns:id
+                      data_type: Int32
+                    - name: value
+                      xml_path: /data/ns:item/ns:value
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("test").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_array_values!(batch, "id", vec![7i32], Int32Array);
+        assert_array_values!(batch, "value", vec![42i32], Int32Array);
+    }
+
+    #[test]
+    fn test_strip_namespaces_false_does_not_strip_prefix() {
+        // The trade-off of the fast path: a prefixed element is matched by its
+        // raw qualified name, so an unqualified config path no longer matches
+        // the prefixed element (contrast with
+        // test_prefixed_namespace_attribute_stripped, where the default strips
+        // the prefix). The `<ns:value>` text never reaches the `value` field, so
+        // it stays null.
+        let xml_content = r#"<data xmlns:ns="http://example.com"><ns:item><ns:value>42</ns:value></ns:item></data>"#;
+        let record_batches = parse(
+            xml_content,
+            r#"
+            parser_options:
+              strip_namespaces: false
+            tables:
+                - name: test
+                  xml_path: /data
+                  levels: [item]
+                  fields:
+                    - name: value
+                      xml_path: /data/item/value
+                      data_type: Int32
+                      nullable: true
+            "#,
+        );
+        let batch = record_batches.get("test").unwrap();
+        let array = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert!(
+            array.iter().all(|v| v.is_none()),
+            "unqualified path must not match the prefixed element"
+        );
     }
 }


### PR DESCRIPTION
Element and attribute names were always resolved via quick-xml's local_name(), which runs a memchr(':') namespace-prefix scan on every name. A function-level profile showed this name resolution is ~5.8% of total parse time, the bulk of it that scan.

Add ParserOptions::strip_namespaces (default true, preserving current behavior). When false, names resolve via the raw qualified name(), skipping the scan. For prefix-free documents name() and local_name() are byte-identical, so disabling is free and existing configs are unaffected; for prefixed input, configured paths must spell out the prefix. Wired as a runtime bool on the converter (like validate_attributes), gating the element Start/Empty and attribute-key sites.

Measured -4.1% to -6.7% across parse_small/parse_medium/parse_wide_fanout (both buffered and zero-copy, p<0.01).