### PR TITLE
fix: resolve character references, phantom rows, and silent value overwrites

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,43 @@ fn default_true() -> bool {
     true
 }
 
+/// Splits an XML path into its segments using the same rules as the path
+/// registry: the leading `/` is ignored and empty segments (double or
+/// trailing slashes) are skipped. Validation and runtime matching must agree
+/// on what a "path" is, so this mirrors `PathRegistry::get_or_create_path`.
+fn path_segments(path: &str) -> impl Iterator<Item = &str> {
+    path.trim_start_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+}
+
+/// Returns true when `descendant` is equal to or nested under `ancestor`,
+/// compared segment-wise. A plain string prefix test is not enough:
+/// `/root/items_other` starts with `/root/item` as a string but is not under
+/// it as a path. The root path `/` has no segments, so everything is under it.
+fn path_is_under(descendant: &str, ancestor: &str) -> bool {
+    // Fast path for canonical spellings: a character-level prefix whose cut
+    // lands on a segment boundary is exactly the segment-wise relation.
+    // Validation runs once per `Parser::new`, but that fixed cost dominates
+    // tiny-document parses, so the common case stays a single memcmp.
+    if let Some(rest) = descendant.strip_prefix(ancestor)
+        && (rest.is_empty() || rest.starts_with('/') || ancestor.ends_with('/'))
+    {
+        return true;
+    }
+    // Slow path normalizes non-canonical spellings (duplicate/trailing
+    // slashes, missing leading slash).
+    let mut descendant_segments = path_segments(descendant);
+    path_segments(ancestor).all(|segment| descendant_segments.next() == Some(segment))
+}
+
+/// Returns true when two paths resolve to the same registry node, i.e. their
+/// normalized segment sequences are identical regardless of spelling
+/// ("/data", "data" and "/data/" are all the same path).
+fn paths_equal(a: &str, b: &str) -> bool {
+    path_segments(a).eq(path_segments(b))
+}
+
 /// Top-level configuration for XML to Arrow conversion.
 ///
 /// This struct holds a collection of `TableConfig` structs, each defining how a specific
@@ -100,11 +137,13 @@ impl Config {
     ///
     /// Checks performed:
     /// - Table names must be non-empty and unique across the configuration.
-    /// - Table `xml_path` values must be non-empty.
+    /// - Table `xml_path` values must be non-empty and unique (segment-wise):
+    ///   the path registry stores one table per path node, so a duplicate
+    ///   would silently starve the earlier table of rows.
     /// - Field names must be non-empty and unique within each table.
     /// - Field `xml_path` values must be non-empty.
-    /// - Field `xml_path` must be a descendant of (or equal to) the parent table's `xml_path`,
-    ///   unless the table's `xml_path` is `/` (root table, which allows any field path).
+    /// - Field `xml_path` must be a descendant of (or equal to) the parent table's
+    ///   `xml_path`, compared per path segment. The root table `/` allows any field path.
     /// - Scale/offset may only be used with Float32 and Float64 fields.
     ///
     /// # Errors
@@ -113,7 +152,7 @@ impl Config {
     pub fn validate(&self) -> Result<()> {
         // --- Table-level checks ---
         let mut table_names = HashSet::with_capacity(self.tables.len());
-        for table in &self.tables {
+        for (table_idx, table) in self.tables.iter().enumerate() {
             if table.name.is_empty() {
                 return Err(Error::InvalidConfig {
                     reason: ConfigIssue::EmptyTableName,
@@ -132,6 +171,22 @@ impl Config {
                         table: table.name.clone(),
                     },
                 });
+            }
+            // Duplicate-path detection compares normalized segments so that
+            // "/data", "data" and "/data/" — which all resolve to the same
+            // registry node — count as duplicates. A pairwise scan (rather
+            // than a hash set of built keys) keeps `Parser::new` free of
+            // per-table allocations; table counts are small.
+            for earlier_table in &self.tables[..table_idx] {
+                if paths_equal(&earlier_table.xml_path, &table.xml_path) {
+                    return Err(Error::InvalidConfig {
+                        reason: ConfigIssue::DuplicateTableXmlPath {
+                            table_a: earlier_table.name.clone(),
+                            table_b: table.name.clone(),
+                            xml_path: table.xml_path.clone(),
+                        },
+                    });
+                }
             }
 
             // --- Field-level checks within this table ---
@@ -161,8 +216,10 @@ impl Config {
                     });
                 }
 
-                // Field path must be under the table path (skip for root table "/").
-                if table.xml_path != "/" && !field.xml_path.starts_with(&table.xml_path) {
+                // Field path must be under the table path, compared per
+                // segment (the root table "/" has no segments and thus
+                // accepts any field path).
+                if !path_is_under(&field.xml_path, &table.xml_path) {
                     return Err(Error::InvalidConfig {
                         reason: ConfigIssue::FieldPathNotUnderTable {
                             table: table.name.clone(),
@@ -991,6 +1048,80 @@ mod tests {
         let err = config.validate().unwrap_err();
         assert!(matches!(err, Error::InvalidConfig { .. }));
         assert!(err.to_string().contains("not under table"));
+    }
+
+    #[test]
+    fn test_field_path_sharing_string_prefix_but_not_segments_rejected() {
+        // "/root/items_other" starts with "/root/item" as a *string* but is
+        // not under it as a *path* — the check must be segment-aware.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![TableConfig::new(
+                "items",
+                "/root/item",
+                vec![],
+                vec![
+                    FieldConfigBuilder::new("value", "/root/items_other/value", DType::Utf8)
+                        .build()
+                        .unwrap(),
+                ],
+            )],
+        };
+        let err = config.validate().unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig { .. }));
+        assert!(err.to_string().contains("not under table"));
+    }
+
+    #[test]
+    fn test_field_path_equal_to_table_path_accepted() {
+        // A field can capture the table element's own text content.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![TableConfig::new(
+                "items",
+                "/root/items",
+                vec![],
+                vec![
+                    FieldConfigBuilder::new("content", "/root/items", DType::Utf8)
+                        .build()
+                        .unwrap(),
+                ],
+            )],
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_table_xml_path_rejected() {
+        // The path registry stores one table per node; a duplicate path
+        // would silently starve the earlier table of rows.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![
+                TableConfig::new("a", "/data", vec![], vec![]),
+                TableConfig::new("b", "/data", vec![], vec![]),
+            ],
+        };
+        let err = config.validate().unwrap_err();
+        assert!(matches!(err, Error::InvalidConfig { .. }));
+        assert!(err.to_string().contains("share the same xml_path"));
+        assert!(err.to_string().contains("'a'"));
+        assert!(err.to_string().contains("'b'"));
+    }
+
+    #[test]
+    fn test_duplicate_table_xml_path_detected_across_spellings() {
+        // "/data", "data" and "/data/" all resolve to the same registry
+        // node, so they must count as duplicates regardless of spelling.
+        let config = Config {
+            parser_options: Default::default(),
+            tables: vec![
+                TableConfig::new("a", "/data", vec![], vec![]),
+                TableConfig::new("b", "data/", vec![], vec![]),
+            ],
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("share the same xml_path"));
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,6 +99,18 @@ pub enum ParseKind {
     },
     /// A boolean token didn't match any recognized form.
     InvalidBoolean,
+    /// An entity reference in element text could not be resolved (not a
+    /// predefined entity, not a character reference). Silently dropping it
+    /// would corrupt the extracted value, so it is surfaced as an error.
+    /// The unresolved reference (without `&`/`;`) travels in
+    /// `ParseError::value`.
+    UnresolvedEntity,
+    /// A field's element reappeared within a single row after a value was
+    /// already captured. Scalar columns can hold one value per row; silently
+    /// concatenating the raw bytes (the historical behavior) fabricated
+    /// values that never appeared in the document. The already-captured
+    /// value travels in `ParseError::value`.
+    DuplicateValue,
 }
 
 /// Which transform was attempted on a type that doesn't support it.
@@ -119,6 +131,14 @@ pub enum ConfigIssue {
     EmptyTableName,
     DuplicateTableName {
         name: String,
+    },
+    /// Two tables resolve to the same `xml_path`. The path registry stores a
+    /// single table per path node, so the earlier table would silently
+    /// receive zero rows — rejected instead.
+    DuplicateTableXmlPath {
+        table_a: String,
+        table_b: String,
+        xml_path: String,
     },
     EmptyTableXmlPath {
         table: String,
@@ -172,6 +192,14 @@ impl fmt::Display for Error {
                     f,
                     "Failed to parse value '{value}' as boolean for field '{field}' at path {path}: expected one of 'true', 'false', '1', '0', 'yes', 'no', 'on', 'off', 't', 'f', 'y', or 'n'"
                 ),
+                ParseKind::UnresolvedEntity => write!(
+                    f,
+                    "Unresolved entity reference '&{value};' for field '{field}' at path {path}: only predefined entities (amp, lt, gt, quot, apos) and character references are supported"
+                ),
+                ParseKind::DuplicateValue => write!(
+                    f,
+                    "Duplicate value for field '{field}' at path {path}: element appeared more than once in a single row (value already captured: '{value}')"
+                ),
             },
             Error::MissingRequiredField { field, path } => write!(
                 f,
@@ -200,6 +228,14 @@ impl fmt::Display for ConfigIssue {
         match self {
             ConfigIssue::EmptyTableName => f.write_str("Table name must not be empty"),
             ConfigIssue::DuplicateTableName { name } => write!(f, "Duplicate table name '{name}'"),
+            ConfigIssue::DuplicateTableXmlPath {
+                table_a,
+                table_b,
+                xml_path,
+            } => write!(
+                f,
+                "Tables '{table_a}' and '{table_b}' share the same xml_path '{xml_path}'; each table must have a distinct xml_path"
+            ),
             ConfigIssue::EmptyTableXmlPath { table } => {
                 write!(f, "Table '{table}' has an empty xml_path")
             }
@@ -423,6 +459,18 @@ mod tests {
                 path: Arc::from("/p"),
                 value: "maybe".into(),
                 kind: ParseKind::InvalidBoolean,
+            },
+            Error::ParseError {
+                field: Arc::from("f"),
+                path: Arc::from("/p"),
+                value: "nbsp".into(),
+                kind: ParseKind::UnresolvedEntity,
+            },
+            Error::ParseError {
+                field: Arc::from("f"),
+                path: Arc::from("/p"),
+                value: "2".into(),
+                kind: ParseKind::DuplicateValue,
             },
             Error::MissingRequiredField {
                 field: Arc::from("f"),

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -24,15 +24,15 @@ use quick_xml::Reader;
 use quick_xml::XmlVersion;
 use quick_xml::encoding::Decoder;
 use quick_xml::escape;
-use quick_xml::events::Event;
 use quick_xml::events::attributes::Attributes;
+use quick_xml::events::{BytesRef, Event};
 
 use crate::Config;
 use crate::config::{DType, FieldConfig, TableConfig};
 use crate::errors::Error;
 use crate::errors::ParseKind;
 use crate::errors::Result;
-use crate::path_registry::{PathNodeId, PathRegistry, PathTracker};
+use crate::path_registry::{PathNodeId, PathNodeInfo, PathRegistry, PathTracker};
 
 // === Field-level accumulation ===
 
@@ -128,6 +128,14 @@ struct FieldBuilder {
     /// The Arrow array builder used to construct the array (enum dispatch, no vtable).
     array_builder: TypedArrayBuilder,
     /// Indicates whether the builder has received any values for the current row.
+    ///
+    /// Doubles as the repeated-element guard: when a field's element is
+    /// *entered* while `has_value` is already set for the current row, the
+    /// element appeared twice — historically the raw bytes were silently
+    /// concatenated ("1" + "2" → 12 for an Int32), fabricating values; now it
+    /// is a `ParseError` (see `check_element_not_repeated`). Text split
+    /// across multiple events *within* one element (text + CDATA, entity
+    /// references) never trips this: no re-entry happens in between.
     has_value: bool,
     /// Pre-computed `meta.scale.is_some() || meta.offset.is_some()`. The
     /// per-row float append path is hot enough that gating the `Option` loads
@@ -568,6 +576,69 @@ impl<'a> XmlToArrowConverter<'a> {
         }
     }
 
+    /// Rejects a repeated occurrence of a field's element within one row.
+    ///
+    /// Called from the `Start`/`Empty` arms when the *entered* node carries
+    /// field mappings (`info` is the `PathNodeInfo` those arms already hold,
+    /// so this adds no registry lookup). If a matching field of the current
+    /// table already accumulated a value in this row, the element is
+    /// appearing a second time — historically the raw bytes were silently
+    /// concatenated ("1" + "2" → 12 for an Int32), fabricating values that
+    /// never appeared in the document; now it is a `ParseError`.
+    ///
+    /// Value-less occurrences (`<v/><v>2</v>`) pass: nothing was captured, so
+    /// the rule is "at most one value-bearing occurrence per row". Duplicate
+    /// *attributes* (reachable with `validate_attributes: false`) are
+    /// intentionally exempt — attribute pseudo-nodes are entered inside
+    /// `parse_attributes`, which does not run this check, preserving the
+    /// documented concatenation behavior for trusted input.
+    #[inline]
+    fn check_element_not_repeated(&self, info: &PathNodeInfo) -> Result<()> {
+        if let Some(current_entry) = self.builder_stack.last() {
+            let current_table_idx = current_entry.table_idx;
+            for &(table_idx, field_idx) in &info.field_indices {
+                if table_idx == current_table_idx
+                    && self.table_builders[table_idx].field_builders[field_idx].has_value
+                {
+                    return Err(self.duplicate_value_error(table_idx, field_idx));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Builds the `DuplicateValue` error for `check_element_not_repeated`.
+    /// Out of line and cold so the check above stays a bare `has_value`
+    /// branch in the per-element hot path; the allocations here only run
+    /// when the parse is already failing.
+    #[cold]
+    #[inline(never)]
+    fn duplicate_value_error(&self, table_idx: usize, field_idx: usize) -> Error {
+        let field_builder = &self.table_builders[table_idx].field_builders[field_idx];
+        Error::ParseError {
+            field: Arc::from(field_builder.meta.name.as_str()),
+            path: Arc::from(field_builder.meta.xml_path.as_str()),
+            value: String::from_utf8_lossy(&field_builder.current_value).into_owned(),
+            kind: ParseKind::DuplicateValue,
+        }
+    }
+
+    /// Returns the metadata of the first field of the *current* table mapped
+    /// to `node_id`, or `None` when a value at this node would not be
+    /// captured. Used by the entity-reference handler to decide whether an
+    /// unresolvable reference is an error (it would corrupt a field value)
+    /// or ignorable (nothing is listening at this node).
+    fn active_field_meta(&self, node_id: PathNodeId) -> Option<&FieldMeta> {
+        let info = self.registry.get_node_info(node_id);
+        let current_table_idx = self.builder_stack.last()?.table_idx;
+        info.field_indices
+            .iter()
+            .find(|(table_idx, _)| *table_idx == current_table_idx)
+            .map(|&(table_idx, field_idx)| {
+                &self.table_builders[table_idx].field_builders[field_idx].meta
+            })
+    }
+
     fn end_current_row(&mut self) -> Result<()> {
         // Collect parent indices into reusable buffer to avoid per-row allocation.
         self.parent_indices_buffer.clear();
@@ -933,7 +1004,12 @@ fn close_element(
     }
     path_tracker.leave();
 
-    if path_tracker.top_is_table() {
+    // Only *configured* elements delimit rows (node_id is Some). Letting an
+    // unknown element finalize a row would fabricate null/empty rows whenever
+    // the document grows siblings the config doesn't know about. Configured
+    // children keep the established behavior: each known direct child of a
+    // table element closing ends a row.
+    if node_id.is_some() && path_tracker.top_is_table() {
         xml_to_arrow_converter.end_current_row()?;
     }
 
@@ -945,6 +1021,59 @@ fn close_element(
         return Ok(LoopAction::Break);
     }
     Ok(LoopAction::Continue)
+}
+
+/// Resolves a general reference in element text (`&#66;`, `&amp;`,
+/// `&custom;`) and appends the resolved bytes to the fields listening at
+/// `node_id`.
+///
+/// Two resolution steps cover the complete vocabulary a non-DTD-aware parser
+/// can handle: character references (`&#66;`, `&#x41;`) and the five
+/// predefined entities. A 4-byte stack buffer keeps the char-ref path
+/// allocation-free. An undeclared/custom entity cannot be resolved without
+/// DTD support; silently dropping it — the historical behavior — corrupted
+/// the extracted value, so it errors instead, but only when a configured
+/// field is actually capturing at this node.
+///
+/// Kept out of line (like `parse_attributes`): references are rare relative
+/// to Start/Text/End events, and inlining this — with its error construction
+/// — would grow `handle_event` for no hot-path benefit.
+#[inline(never)]
+fn handle_general_ref(
+    e: BytesRef<'_>,
+    node_id: PathNodeId,
+    xml_to_arrow_converter: &mut XmlToArrowConverter<'_>,
+) -> Result<()> {
+    if let Some(ch) = e.resolve_char_ref()? {
+        let mut utf8_buf = [0u8; 4];
+        let encoded = ch.encode_utf8(&mut utf8_buf);
+        xml_to_arrow_converter.set_field_value_for_node(node_id, encoded.as_bytes());
+        return Ok(());
+    }
+
+    // The predefined-entity lookup requires a `&str`, but the vocabulary
+    // (`amp`, `lt`, `gt`, `quot`, `apos`) is ASCII, so invalid UTF-8 simply
+    // fails to resolve.
+    let text = e.into_inner();
+    let resolved = std::str::from_utf8(&text)
+        .ok()
+        .and_then(escape::resolve_predefined_entity);
+    match resolved {
+        Some(entity_text) => {
+            xml_to_arrow_converter.set_field_value_for_node(node_id, entity_text.as_bytes());
+        }
+        None => {
+            if let Some(meta) = xml_to_arrow_converter.active_field_meta(node_id) {
+                return Err(Error::ParseError {
+                    field: Arc::from(meta.name.as_str()),
+                    path: Arc::from(meta.xml_path.as_str()),
+                    value: String::from_utf8_lossy(&text).into_owned(),
+                    kind: ParseKind::UnresolvedEntity,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Processes a single XML event, updating path tracking, table builders, and field values.
@@ -984,12 +1113,22 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
             };
 
             // Fused lookup: child resolution + node-info read in one pass.
-            // The `&PathNodeInfo` borrow is dropped before any mutable use
-            // of the converter by extracting the bits we need into Copy
+            // The `&PathNodeInfo` borrow is tied to the registry (not the
+            // converter), so the repeated-element check can run on it before
+            // the bits the rest of the arm needs are extracted into Copy
             // locals.
             let (node_id_opt, table_index, has_attrs) =
                 match path_tracker.enter(name_bytes, xml_to_arrow_converter.registry) {
-                    Some((id, info)) => (Some(id), info.table_index, info.has_attribute_children),
+                    Some((id, info)) => {
+                        // Re-entering a field element whose row value is
+                        // already set means the element appeared twice —
+                        // rejected while `info` is in hand (no extra
+                        // registry read; see check_element_not_repeated).
+                        if !info.field_indices.is_empty() {
+                            xml_to_arrow_converter.check_element_not_repeated(info)?;
+                        }
+                        (Some(id), info.table_index, info.has_attribute_children)
+                    }
                     None => (None, None, false),
                 };
 
@@ -1021,12 +1160,18 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
 
             let (node_id_opt, table_index, has_attrs, is_table) =
                 match path_tracker.enter(name_bytes, xml_to_arrow_converter.registry) {
-                    Some((id, info)) => (
-                        Some(id),
-                        info.table_index,
-                        info.has_attribute_children,
-                        info.is_table(),
-                    ),
+                    Some((id, info)) => {
+                        // Same repeated-element guard as Event::Start.
+                        if !info.field_indices.is_empty() {
+                            xml_to_arrow_converter.check_element_not_repeated(info)?;
+                        }
+                        (
+                            Some(id),
+                            info.table_index,
+                            info.has_attribute_children,
+                            info.is_table(),
+                        )
+                    }
                     None => (None, None, false, false),
                 };
 
@@ -1058,17 +1203,7 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
         }
         Event::GeneralRef(e) => {
             if let Some(node_id) = path_tracker.current() {
-                let text = e.into_inner();
-                // The predefined-entity lookup requires a `&str`, but the
-                // vocabulary (`amp`, `lt`, `gt`, `quot`, `apos`) is ASCII, so
-                // invalid UTF-8 here just yields no resolution — consistent
-                // with the previous unwrap_or_default behavior for unknown
-                // entities.
-                let resolved = std::str::from_utf8(&text)
-                    .ok()
-                    .and_then(escape::resolve_predefined_entity)
-                    .unwrap_or_default();
-                xml_to_arrow_converter.set_field_value_for_node(node_id, resolved.as_bytes());
+                handle_general_ref(e, node_id, xml_to_arrow_converter)?;
             }
         }
         Event::Text(e) => {
@@ -5186,5 +5321,349 @@ mod tests {
             array.iter().all(|v| v.is_none()),
             "unqualified path must not match the prefixed element"
         );
+    }
+
+    // =========================================================================
+    // Character / entity references in element text
+    // =========================================================================
+
+    #[test]
+    fn test_decimal_char_ref_in_text_resolved() {
+        // Regression: character references used to resolve to an empty
+        // string, silently dropping data ("A&#66;C" became "AC").
+        let record_batches = parse(
+            r#"<data><row><v>A&#66;C</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec!["ABC"], StringArray);
+    }
+
+    #[test]
+    fn test_hex_char_ref_in_text_resolved() {
+        let record_batches = parse(
+            r#"<data><row><v>X&#x41;Y</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec!["XAY"], StringArray);
+    }
+
+    #[test]
+    fn test_multibyte_char_ref_in_text_resolved() {
+        // A code point above ASCII exercises the full 4-byte UTF-8 encode
+        // path (U+1F30D 🌍).
+        let record_batches = parse(
+            r#"<data><row><v>&#127757;</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec!["🌍"], StringArray);
+    }
+
+    #[test]
+    fn test_char_ref_in_numeric_field_parsed() {
+        // A char ref can form part of a numeric value; the resolved bytes
+        // must flow into the numeric parser like ordinary text.
+        let record_batches = parse(
+            r#"<data><row><v>4&#50;</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec![42i32], Int32Array);
+    }
+
+    #[test]
+    fn test_unknown_entity_in_captured_field_returns_error() {
+        // An undeclared entity cannot be resolved without DTD support.
+        // Dropping it silently (the old behavior) corrupted the value, so it
+        // must surface as a ParseError naming the entity.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#
+        );
+        let result = parse_xml(
+            r#"<data><row><v>a&nbsp;b</v></row></data>"#.as_bytes(),
+            &config,
+        );
+        match result.unwrap_err() {
+            e @ Error::ParseError {
+                kind: ParseKind::UnresolvedEntity,
+                ..
+            } => assert!(e.to_string().contains("nbsp")),
+            e => panic!("Expected UnresolvedEntity ParseError, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn test_unknown_entity_outside_captured_fields_ignored() {
+        // The same unresolvable entity in a part of the document no field
+        // captures must not fail the parse — nothing is listening there.
+        let record_batches = parse(
+            r#"<data><notes>a&nbsp;b</notes><row><v>1</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec![1i32], Int32Array);
+    }
+
+    #[test]
+    fn test_malformed_char_ref_returns_error() {
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#
+        );
+        let result = parse_xml(
+            r#"<data><row><v>&#xZZ;</v></row></data>"#.as_bytes(),
+            &config,
+        );
+        assert!(result.is_err(), "invalid char ref digits must error");
+    }
+
+    // =========================================================================
+    // Row finalization: only configured elements delimit rows
+    // =========================================================================
+
+    #[test]
+    fn test_unknown_sibling_under_table_does_not_create_row() {
+        // Regression: an element the config doesn't know about, sitting
+        // directly under a table path, used to finalize a spurious all-null
+        // row. Unknown elements must be invisible to row accounting.
+        let record_batches = parse(
+            r#"
+            <data>
+                <item><v>1</v></item>
+                <unrelated>junk</unrelated>
+                <item><v>2</v></item>
+            </data>
+            "#,
+            r#"
+            tables:
+                - name: items
+                  xml_path: /data
+                  levels: [item]
+                  fields:
+                    - name: v
+                      xml_path: /data/item/v
+                      data_type: Int32
+                      nullable: true
+            "#,
+        );
+        let batch = record_batches.get("items").unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_array_values!(batch, "v", vec![1i32, 2], Int32Array);
+        assert_array_values!(batch, "<item>", vec![0u32, 1], UInt32Array);
+    }
+
+    #[test]
+    fn test_unknown_self_closing_sibling_under_table_does_not_create_row() {
+        // Same rule for the Event::Empty path.
+        let record_batches = parse(
+            r#"<data><item><v>1</v></item><unrelated/></data>"#,
+            r#"
+            tables:
+                - name: items
+                  xml_path: /data
+                  levels: [item]
+                  fields:
+                    - name: v
+                      xml_path: /data/item/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("items").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_array_values!(batch, "v", vec![1i32], Int32Array);
+    }
+
+    #[test]
+    fn test_unknown_sibling_with_non_nullable_fields_does_not_error() {
+        // Before the fix the spurious row also *failed* the whole parse when
+        // any field was non-nullable (the null row violated nullability).
+        // Robustness against schema evolution of the input demands this
+        // parses cleanly.
+        let record_batches = parse(
+            r#"<data><item><v>1</v></item><added_in_v2>x</added_in_v2></data>"#,
+            r#"
+            tables:
+                - name: items
+                  xml_path: /data
+                  levels: [item]
+                  fields:
+                    - name: v
+                      xml_path: /data/item/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("items").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+    }
+
+    // =========================================================================
+    // Repeated field elements within one row
+    // =========================================================================
+
+    #[test]
+    fn test_repeated_element_value_returns_error() {
+        // Regression: two occurrences of a field's element in one row used to
+        // concatenate raw bytes — "1" + "2" parsed as 12 for Int32,
+        // fabricating a value that never appeared in the document.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let result = parse_xml(
+            r#"<data><row><v>1</v><v>2</v></row></data>"#.as_bytes(),
+            &config,
+        );
+        match result.unwrap_err() {
+            e @ Error::ParseError {
+                kind: ParseKind::DuplicateValue,
+                ..
+            } => assert!(e.to_string().contains("more than once")),
+            e => panic!("Expected DuplicateValue ParseError, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn test_valueless_occurrence_then_value_accepted() {
+        // The guard fires when an element is *re-entered with a value
+        // already captured*: an empty first occurrence contributed nothing,
+        // so a later value is not a conflict.
+        let record_batches = parse(
+            r#"<data><row><v/><v>2</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec![2i32], Int32Array);
+    }
+
+    #[test]
+    fn test_value_then_repeated_element_returns_error() {
+        // Once a value is captured, any re-occurrence of the element in the
+        // same row — even a self-closing one — is rejected: the document is
+        // presenting multiple candidates for a scalar column.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let result = parse_xml(
+            r#"<data><row><v>1</v><v/></row></data>"#.as_bytes(),
+            &config,
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::ParseError {
+                kind: ParseKind::DuplicateValue,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_same_field_element_across_rows_unaffected_by_sealing() {
+        // Sealing is per row: the same element reappearing in the *next* row
+        // is the normal case and must keep working.
+        let record_batches = parse(
+            r#"<data><row><v>1</v></row><row><v>2</v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "v", vec![1i32, 2], Int32Array);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -369,6 +369,59 @@ fn test_whitespace_only_file_returns_empty_batch() {
 }
 
 // ---------------------------------------------------------------------------
+// Bug reproductions (fixed defects, pinned end-to-end)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_character_references_in_text_survive_file_roundtrip() {
+    // Regression: "&#66;" / "&#x41;" in element text used to resolve to an
+    // empty string, silently corrupting extracted values.
+    let batches = parse_xml_file(
+        r#"<data><item><name>A&#66;C &#x2013; done</name></item></data>"#,
+        r#"
+        tables:
+          - name: items
+            xml_path: /data
+            levels: []
+            fields:
+              - name: name
+                xml_path: /data/item/name
+                data_type: Utf8
+        "#,
+    );
+    let batch = batches.get("items").unwrap();
+    assert_array_values!(batch, "name", &["ABC – done"], StringArray);
+}
+
+#[test]
+fn test_unconfigured_elements_do_not_fabricate_rows() {
+    // Regression: an element the config doesn't map, directly under a table
+    // path, used to finalize a spurious all-null row — so documents gaining
+    // new sibling elements broke row counts (and errored on non-nullable
+    // fields).
+    let batches = parse_xml_file(
+        r#"<data>
+            <item><id>1</id></item>
+            <schema_v2_extension><stuff>x</stuff></schema_v2_extension>
+            <item><id>2</id></item>
+        </data>"#,
+        r#"
+        tables:
+          - name: items
+            xml_path: /data
+            levels: [item]
+            fields:
+              - name: id
+                xml_path: /data/item/id
+                data_type: Int32
+        "#,
+    );
+    let batch = batches.get("items").unwrap();
+    assert_eq!(batch.num_rows(), 2);
+    assert_array_values!(batch, "id", &[1, 2], Int32Array);
+}
+
+// ---------------------------------------------------------------------------
 // Realistic end-to-end scenario
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes five confirmed parser/validation defects:

- Character and entity references in element text were silently dropped, corrupting captured values (e.g. "A&#66;C" parsed as "AC"). Character references are now resolved and the predefined XML entities (amp, lt, gt, quot, apos) are substituted; an unresolvable entity inside a captured field raises the new ParseKind::UnresolvedEntity instead of corrupting data. Entities outside captured fields remain ignored.

- Unconfigured child elements of a table's xml_path incorrectly finalized rows, fabricating extra empty rows when documents contained elements not present in the config. Only registry-known (configured) child elements delimit rows now.

- A repeated value-bearing occurrence of a field's element within one row silently overwrote the previously captured value. This now raises the new ParseKind::DuplicateValue error. A value-less occurrence before the value-bearing one (<v/><v>2</v>) remains accepted.

- Config::validate accepted a field xml_path that merely shared a string prefix with its table's xml_path (e.g. field /items_extra under table /items). Path containment is now checked segment-wise.

- Config::validate accepted two tables with the same xml_path, which produced ambiguous row attribution. This now fails at load with the new ConfigIssue::DuplicateTableXmlPath.

The GeneralRef and duplicate-value error paths are outlined with #[cold]/#[inline(never)] to keep handle_event small; benchmarks show no regression outside machine noise (parse_small buffered -1.6%, wide_fanout buffered +2.5%, others unchanged).