### PR TITLE
fix: reject digit-prefixed garbage and treat whitespace-only numerics as missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ tables:
                                # (e.g. /library/book/@id)
         data_type: <type>      # Arrow data type — see supported types below
         nullable: <true|false> # Whether the field can be null (default: false)
-                               # If false, missing/empty tags cause a ParseError.
+                               # If false, a missing/empty value is an error —
+                               # except Utf8 fields, which yield "" (see below)
         scale: <number>        # Multiply float values by this factor (optional)
         offset: <number>       # Add this value to float values after scaling (optional)
                                # value = (value * scale) + offset
@@ -78,6 +79,14 @@ tables:
 
 `Boolean` fields accept (case-insensitively): `true`, `false`, `1`, `0`, `yes`,
 `no`, `on`, `off`, `t`, `f`, `y`, `n`.
+
+**Whitespace and missing values:** numeric and boolean values may be surrounded
+by whitespace (`<v> 42 </v>`, `age=" 30 "`) regardless of the `trim_text`
+setting; a whitespace-only or empty value counts as *missing* — null when the
+field is `nullable`, an error otherwise. Trailing garbage after a number
+(`30 units`, `1.5` for an integer field) is a parse error, never a silent
+truncation. One exception to the missing-value rule: a missing non-nullable
+`Utf8` field yields an empty string `""` rather than an error.
 
 ### 2. Nested tables and `levels`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -362,9 +362,7 @@ pub struct FieldConfig {
     /// (for numeric and boolean fields) whitespace-only. When `nullable` is
     /// `false`, a missing value raises `MissingRequiredField` — with one
     /// long-standing exception: **`Utf8` fields append an empty string
-    /// instead of erroring** (pinned by
-    /// `test_missing_string_defaults_to_empty`; a per-field `missing` policy
-    /// is planned for the v2 config to make this declarable).
+    /// instead of erroring**.
     #[serde(default)]
     pub nullable: bool,
     /// Multiplier applied to `Float32`/`Float64` values:

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,9 @@ impl Config {
 
     /// Creates a `Config` struct from a YAML configuration file.
     ///
-    /// This function reads a YAML file at the given path and deserializes it into a `Config` struct.
+    /// This function reads a YAML file at the given path, deserializes it into a
+    /// `Config` struct, and runs [`Config::validate`] on the result — a config
+    /// obtained here is always structurally valid.
     ///
     /// # Arguments
     ///
@@ -248,8 +250,9 @@ impl Config {
     ///
     /// A `Result` containing:
     ///
-    /// *   `Ok(Config)`: The deserialized `Config` struct.
-    /// *   `Err(Error)`: An `Error` value if the file cannot be opened, read, or parsed as YAML.
+    /// *   `Ok(Config)`: The deserialized and validated `Config` struct.
+    /// *   `Err(Error)`: An `Error` value if the file cannot be opened, read, or
+    ///     parsed as YAML, or if the configuration fails validation.
     ///
     /// # Errors
     ///
@@ -257,6 +260,10 @@ impl Config {
     ///
     /// *   `Error::Io`: If an I/O error occurs while opening or reading the file.
     /// *   `Error::Yaml`: If there is an error parsing the YAML data.
+    /// *   `Error::InvalidConfig`: If the configuration fails [`Config::validate`]
+    ///     (e.g. duplicate table names, a field path not under its table path).
+    /// *   `Error::UnsupportedConversion`: If a scale/offset is configured on a
+    ///     non-float field.
     pub fn from_yaml_file(path: impl AsRef<Path>) -> Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
@@ -315,9 +322,10 @@ impl Config {
 
 /// Configuration for an XML table to be parsed into an Arrow record batch.
 ///
-/// This struct defines how an XML structure should be interpreted as a table, including
-/// the path to the table elements, the element representing a row, and the configuration
-/// of the fields (columns) within the table.
+/// This struct defines how an XML structure should be interpreted as a table:
+/// the path to the element whose configured direct children delimit rows, the
+/// index columns linking nested tables (`levels`), and the configuration of
+/// the fields (columns) within the table.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct TableConfig {
     /// The name of the table.
@@ -560,9 +568,9 @@ impl DType {
 /// input or files, use [`Config::from_yaml_file`] or `yaml_serde::from_str`
 /// directly and handle the error.
 ///
-/// Despite the name, parsing happens at runtime when the macro is expanded
-/// and evaluated; Rust does not support compile-time YAML deserialization
-/// without a procedural macro.
+/// The macro is purely syntactic convenience: the YAML string is parsed at
+/// runtime, when the expanded expression is evaluated. Rust does not support
+/// compile-time YAML deserialization without a procedural macro.
 #[macro_export]
 macro_rules! config_from_yaml {
     ($yaml:expr) => {{

--- a/src/config.rs
+++ b/src/config.rs
@@ -357,11 +357,21 @@ pub struct FieldConfig {
     /// The data type of the field. This determines the Arrow data type of the resulting column.
     pub data_type: DType,
     /// Whether the field is nullable (can contain null values). Defaults to false.
+    ///
+    /// A value is *missing* when the element/attribute is absent, empty, or
+    /// (for numeric and boolean fields) whitespace-only. When `nullable` is
+    /// `false`, a missing value raises `MissingRequiredField` — with one
+    /// long-standing exception: **`Utf8` fields append an empty string
+    /// instead of erroring** (pinned by
+    /// `test_missing_string_defaults_to_empty`; a per-field `missing` policy
+    /// is planned for the v2 config to make this declarable).
     #[serde(default)]
     pub nullable: bool,
-    /// Scale for decimal types.
+    /// Multiplier applied to `Float32`/`Float64` values:
+    /// `value = (value * scale) + offset`. Rejected on any other data type.
     pub scale: Option<f64>,
-    /// Offset for decimal types.
+    /// Constant added to `Float32`/`Float64` values *after* scaling:
+    /// `value = (value * scale) + offset`. Rejected on any other data type.
     pub offset: Option<f64>,
 }
 

--- a/src/path_registry.rs
+++ b/src/path_registry.rs
@@ -8,7 +8,8 @@
 // Design overview (top-down narrative):
 //
 // 1) Build-time: PathRegistry::from_config
-//    - Convert every table path and field path into a trie of interned atoms.
+//    - Convert every table path and field path into a trie whose edges are
+//      path segments stored as raw bytes.
 //    - Store table/field metadata at the terminal node of each path.
 //    - Use integer IDs so lookups are array indexing rather than hash maps.
 //
@@ -18,8 +19,8 @@
 //      If the current path is not in the registry, mark the subtree as unknown
 //      to skip further lookups until we pop back out.
 //
-// This design intentionally favors predictable O(1) operations during parsing
-// over upfront construction work at startup.
+// This design intentionally accepts upfront construction work at startup in
+// exchange for predictable, allocation-free lookups during parsing.
 
 use fxhash::FxHashMap;
 
@@ -84,7 +85,7 @@ impl PathNodeInfo {
 
 /// Registry for efficient path lookups during XML parsing.
 ///
-/// The registry compiles all configured XML paths into a trie of interned strings (`Atom`).
+/// The registry compiles all configured XML paths into a trie keyed by path-segment bytes.
 /// Each node in the trie is assigned a compact integer ID (`PathNodeId`), allowing the parser
 /// to operate entirely on IDs using direct array indexing, avoiding string hashing in the hot loop.
 ///
@@ -350,10 +351,10 @@ struct StackEntry {
 /// root, so the stack is never empty.
 ///
 /// Each frame carries the few bits the parser needs at `Event::End` /
-/// `Event::Empty` time (is_table, is_known). The previous design kept those
-/// in a parallel `element_stack` plus a separate `node_info[]` lookup at
-/// close time; folding them onto this stack saves a Vec push/pop and a
-/// cache-line read per element.
+/// `Event::Empty` time (`is_table`, `is_known`), captured once when `enter()`
+/// resolves the node. Closing an element therefore never re-reads
+/// `node_info[]` — a single stack pop answers both "was this a table?" and
+/// (via the new top) "does the parent finalize a row?".
 ///
 /// If a path is unknown, we keep pushing "unknown" placeholder frames until
 /// we exit that subtree. This avoids repeated registry lookups for

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -392,7 +392,7 @@ impl FieldBuilder {
 // === Table-level batching ===
 // A TableBuilder owns per-field builders plus index builders for nested levels.
 // It finalizes rows into a RecordBatch in a single, ordered pass.
-///
+
 /// The subset of a `TableConfig` that finalization needs.
 ///
 /// `TableBuilder` used to hold a full `TableConfig` clone (including the
@@ -520,11 +520,8 @@ struct TableStackEntry {
     node_id: PathNodeId,
 }
 
-/// Converts parsed XML events into Arrow `RecordBatch`es.
-///
-/// This struct maintains a stack of table builders to handle nested XML structures.
-/// It uses integer-based path indexing via `PathRegistry` for efficient lookups.
-/// The mutable, per-parse half of the conversion.
+/// Converts parsed XML events into Arrow `RecordBatch`es — the mutable,
+/// per-parse half of the conversion.
 ///
 /// Everything here holds parse-specific state (the Arrow builders that
 /// accumulate values, the active table stack, scratch buffers) and so must be
@@ -898,9 +895,9 @@ impl Parser {
 /// `Config`, construct a [`Parser`] once and reuse it — that amortizes the
 /// one-time path-compilation cost this wrapper pays on every call.
 ///
-/// This function takes a reader implementing the `BufRead` trait (e.g., a `File`, `&[u8]`, or `String`)
-/// and a `Config` struct that defines the structure of the XML data and how it should be mapped
-/// to Arrow tables.
+/// This function takes a reader implementing the `BufRead` trait (e.g., a
+/// `BufReader<File>` or a `&[u8]` slice) and a `Config` struct that defines the
+/// structure of the XML data and how it should be mapped to Arrow tables.
 ///
 /// # Arguments
 ///
@@ -911,8 +908,8 @@ impl Parser {
 ///
 /// A `Result` containing:
 ///
-/// *   `Ok(IndexMap<String, RecordBatch>)`: An `IndexMap` where keys are the XML names of the tables (as defined in the config)
-///     and values are the corresponding Arrow `RecordBatch` objects.
+/// *   `Ok(IndexMap<String, RecordBatch>)`: An `IndexMap` where keys are the table names (as defined
+///     in the config) and values are the corresponding Arrow `RecordBatch` objects.
 /// *   `Err(Error)`: An `Error` value if any error occurs during parsing, configuration, or Arrow table creation.
 ///
 /// # Errors
@@ -1242,9 +1239,9 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
         }
         Event::End(_) => {
             // Read this element's own (node_id, is_table) from the top of
-            // the merged stack BEFORE close_element pops it via leave().
-            // peek_top() returns None when the stack is at root, matching
-            // the prior "End with empty element_stack ⇒ no-op" behavior.
+            // the path-tracker stack BEFORE close_element pops it via
+            // leave(). peek_top() returns None at root depth, so a stray
+            // End with no matching open element is a no-op.
             if let Some((node_id_opt, is_table)) = path_tracker.peek_top() {
                 return close_element(
                     node_id_opt,

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -188,7 +188,7 @@ fn parse_boolean_token(value: &[u8]) -> std::result::Result<Option<bool>, ()> {
 /// message — this path only runs when parsing fails, so the extra UTF-8 check
 /// is free for the hot case.
 ///
-/// Surrounding ASCII whitespace is ignored (S1): data XML routinely
+/// Surrounding ASCII whitespace is ignored: data XML routinely
 /// pretty-prints values, `trim_text` never covers attributes, and the boolean
 /// path already trims — numerics matching it makes whitespace tolerance
 /// uniform. `trim_ascii` is a zero-copy subslice; for already-clean values
@@ -5689,7 +5689,7 @@ mod tests {
         assert_array_values!(batch, "v", vec![1i32, 2], Int32Array);
     }
 
-    // --- S1: numeric whitespace tolerance + C6: digit-prefix truncation ---
+    // --- Numeric parsing: whitespace tolerance & rejection of trailing garbage ---
 
     #[test]
     fn test_numeric_values_tolerate_surrounding_whitespace() {

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -5765,9 +5765,12 @@ mod tests {
                       data_type: Int32
             "#
         );
-        let err = parse_xml(r#"<data><row><v>   </v></row></data>"#.as_bytes(), &config)
-            .unwrap_err();
-        assert!(matches!(err, Error::MissingRequiredField { .. }), "got: {err}");
+        let err =
+            parse_xml(r#"<data><row><v>   </v></row></data>"#.as_bytes(), &config).unwrap_err();
+        assert!(
+            matches!(err, Error::MissingRequiredField { .. }),
+            "got: {err}"
+        );
     }
 
     #[rstest]
@@ -5816,7 +5819,12 @@ mod tests {
                       data_type: Int32
             "#,
         );
-        assert_array_values!(record_batches.get("t").unwrap(), "v", vec![-42i32], Int32Array);
+        assert_array_values!(
+            record_batches.get("t").unwrap(),
+            "v",
+            vec![-42i32],
+            Int32Array
+        );
 
         let config = config_from_yaml!(
             r#"
@@ -5830,8 +5838,11 @@ mod tests {
                       data_type: Int32
             "#
         );
-        let err = parse_xml(b"<data><row><v>99999999999</v></row></data>".as_slice(), &config)
-            .unwrap_err();
+        let err = parse_xml(
+            b"<data><row><v>99999999999</v></row></data>".as_slice(),
+            &config,
+        )
+        .unwrap_err();
         assert!(matches!(err, Error::ParseError { .. }), "got: {err}");
         assert!(err.to_string().contains("too large"), "got: {err}");
     }
@@ -5852,8 +5863,8 @@ mod tests {
                       data_type: Int32
             "#
         );
-        let err = parse_xml(r#"<data><row><v> 3x </v></row></data>"#.as_bytes(), &config)
-            .unwrap_err();
+        let err =
+            parse_xml(r#"<data><row><v> 3x </v></row></data>"#.as_bytes(), &config).unwrap_err();
         assert!(matches!(err, Error::ParseError { .. }), "got: {err}");
         assert!(err.to_string().contains("' 3x '"), "got: {err}");
     }

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -187,13 +187,31 @@ fn parse_boolean_token(value: &[u8]) -> std::result::Result<Option<bool>, ()> {
 /// the underlying `IntErrorKind` (overflow, invalid digit, etc.) in the error
 /// message — this path only runs when parsing fails, so the extra UTF-8 check
 /// is free for the hot case.
+///
+/// Surrounding ASCII whitespace is ignored (S1): data XML routinely
+/// pretty-prints values, `trim_text` never covers attributes, and the boolean
+/// path already trims — numerics matching it makes whitespace tolerance
+/// uniform. `trim_ascii` is a zero-copy subslice; for already-clean values
+/// both scans terminate on the first byte, so the hot path pays two
+/// predictable compares. A whitespace-only value counts as *missing* (null
+/// when nullable, `MissingRequiredField` otherwise), exactly like boolean.
+/// The `ParseError` for genuinely bad text keeps the raw untrimmed value so
+/// diagnostics show what the document actually contained.
 macro_rules! append_int {
-    ($builder:expr, $value:expr, $has_value:expr, $field_config:expr, $ty:ty, $type_name:expr) => {
-        if $has_value {
-            match atoi::atoi::<$ty>($value) {
-                Some(val) => $builder.append_value(val),
-                None => {
-                    let as_str = std::str::from_utf8($value).unwrap_or("");
+    ($builder:expr, $value:expr, $has_value:expr, $field_config:expr, $ty:ty, $type_name:expr) => {{
+        let trimmed = $value.trim_ascii();
+        if $has_value && !trimmed.is_empty() {
+            // NOT `atoi::atoi`: that parses the longest digit *prefix* and
+            // silently discards the rest — "3x" became 3 and "1.5" became 1.
+            // The checked radix-10 primitive reports how many bytes it
+            // consumed, so requiring full consumption rejects trailing
+            // garbage while keeping the digits-only fast path branch-free.
+            // Overflow (None with bytes consumed) and every partial match
+            // fall through to `str::parse` purely for its precise error.
+            match <$ty as atoi::FromRadix10SignedChecked>::from_radix_10_signed_checked(trimmed) {
+                (Some(val), used) if used == trimmed.len() => $builder.append_value(val),
+                _ => {
+                    let as_str = std::str::from_utf8(trimmed).unwrap_or("");
                     match as_str.parse::<$ty>() {
                         Ok(val) => $builder.append_value(val),
                         Err(e) => {
@@ -218,7 +236,7 @@ macro_rules! append_int {
                 path: Arc::from($field_config.xml_path.as_str()),
             });
         }
-    };
+    }};
 }
 
 /// Helper macro for parsing and appending float values using `fast_float2`.
@@ -228,10 +246,14 @@ macro_rules! append_int {
 /// it avoids two memory loads + branches per value in the (very common) case
 /// where neither transform is configured. `scale as $ty` is a no-op for `f64`
 /// and a truncating cast for `f32`.
+///
+/// Whitespace handling mirrors `append_int!` (see its doc): surrounding ASCII
+/// whitespace is ignored, whitespace-only counts as missing.
 macro_rules! append_float {
-    ($builder:expr, $value:expr, $has_value:expr, $field_config:expr, $has_transform:expr, $ty:ty, $type_name:expr) => {
-        if $has_value {
-            match fast_float2::parse::<$ty, _>($value) {
+    ($builder:expr, $value:expr, $has_value:expr, $field_config:expr, $has_transform:expr, $ty:ty, $type_name:expr) => {{
+        let trimmed = $value.trim_ascii();
+        if $has_value && !trimmed.is_empty() {
+            match fast_float2::parse::<$ty, _>(trimmed) {
                 Ok(mut val) => {
                     if $has_transform {
                         #[allow(clippy::cast_possible_truncation)]
@@ -265,7 +287,7 @@ macro_rules! append_float {
                 path: Arc::from($field_config.xml_path.as_str()),
             });
         }
-    };
+    }};
 }
 
 impl FieldBuilder {
@@ -5665,5 +5687,174 @@ mod tests {
         );
         let batch = record_batches.get("t").unwrap();
         assert_array_values!(batch, "v", vec![1i32, 2], Int32Array);
+    }
+
+    // --- S1: numeric whitespace tolerance + C6: digit-prefix truncation ---
+
+    #[test]
+    fn test_numeric_values_tolerate_surrounding_whitespace() {
+        // Elements with trim_text at its default (off) AND attributes (which
+        // trim_text never covers) both parse: numeric whitespace handling no
+        // longer depends on the global reader option, matching the boolean
+        // path's long-standing behavior.
+        let record_batches = parse(
+            "<data><row attr=\" 7 \"><i>\t 42 \n</i><f> 3.5 </f></row></data>",
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: attr
+                      xml_path: /data/row/@attr
+                      data_type: Int32
+                    - name: i
+                      xml_path: /data/row/i
+                      data_type: Int64
+                    - name: f
+                      xml_path: /data/row/f
+                      data_type: Float64
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values!(batch, "attr", vec![7i32], Int32Array);
+        assert_array_values!(batch, "i", vec![42i64], Int64Array);
+        assert_array_values!(batch, "f", vec![3.5f64], Float64Array);
+    }
+
+    #[test]
+    fn test_whitespace_only_numeric_is_null_when_nullable() {
+        // Whitespace-only counts as *missing*, exactly like the boolean path
+        // — not as a parse error.
+        let record_batches = parse(
+            r#"<data><row><v>   </v><f>  </f></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+                      nullable: true
+                    - name: f
+                      xml_path: /data/row/f
+                      data_type: Float32
+                      nullable: true
+            "#,
+        );
+        let batch = record_batches.get("t").unwrap();
+        assert_array_values_option!(batch, "v", vec![None::<i32>], Int32Array);
+        assert_array_values_option!(batch, "f", vec![None::<f32>], Float32Array);
+    }
+
+    #[test]
+    fn test_whitespace_only_numeric_errors_as_missing_when_non_nullable() {
+        // Non-nullable + whitespace-only must surface as MissingRequiredField
+        // (a config problem: mark it nullable), not as a number-parse error.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let err = parse_xml(r#"<data><row><v>   </v></row></data>"#.as_bytes(), &config)
+            .unwrap_err();
+        assert!(matches!(err, Error::MissingRequiredField { .. }), "got: {err}");
+    }
+
+    #[rstest]
+    #[case::trailing_letter("3x")]
+    #[case::trailing_words("30 units")]
+    #[case::decimal_point("1.5")]
+    #[case::internal_space("1 2")]
+    fn test_digit_prefixed_garbage_errors_instead_of_truncating(#[case] value: &str) {
+        // Regression: `atoi::atoi` parses the longest digit *prefix*, so all
+        // of these silently truncated ("3x" → 3, "1.5" → 1) before the
+        // full-consumption check. They must be parse errors.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let xml = format!("<data><row><v>{value}</v></row></data>");
+        let err = parse_xml(xml.as_bytes(), &config).unwrap_err();
+        assert!(
+            matches!(err, Error::ParseError { .. }),
+            "value {value:?} must error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_signed_and_overflow_integers_after_checked_parse() {
+        // The checked-radix path must keep accepting signs and keep routing
+        // overflow through the fallback for its precise error message.
+        let record_batches = parse(
+            r#"<data><row><v> -42 </v></row></data>"#,
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#,
+        );
+        assert_array_values!(record_batches.get("t").unwrap(), "v", vec![-42i32], Int32Array);
+
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let err = parse_xml(b"<data><row><v>99999999999</v></row></data>".as_slice(), &config)
+            .unwrap_err();
+        assert!(matches!(err, Error::ParseError { .. }), "got: {err}");
+        assert!(err.to_string().contains("too large"), "got: {err}");
+    }
+
+    #[test]
+    fn test_invalid_numeric_error_preserves_raw_untrimmed_value() {
+        // Parsing consumes the trimmed slice, but diagnostics must show what
+        // the document actually contained, whitespace included.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Int32
+            "#
+        );
+        let err = parse_xml(r#"<data><row><v> 3x </v></row></data>"#.as_bytes(), &config)
+            .unwrap_err();
+        assert!(matches!(err, Error::ParseError { .. }), "got: {err}");
+        assert!(err.to_string().contains("' 3x '"), "got: {err}");
     }
 }


### PR DESCRIPTION
Two related numeric-parsing fixes in the append macros:

1. Silent truncation (data loss): `atoi::atoi` parses the longest digit *prefix* and ignores the rest, so "3x" parsed as 3, "30 units" as 30, and "1.5" in an Int32 column as 1 — no error, no warning. Integer parsing now goes through the checked radix-10 primitive and requires full consumption of the (trimmed) value; anything partial falls through to str::parse for its precise error message. Floats were never affected (fast_float2 already requires full consumption).

2. Whitespace tolerance: numeric values now ignore surrounding ASCII whitespace independent of the global `trim_text` option (which never covered attributes), matching the boolean path's behavior. A whitespace-only value counts as missing — null when the field is nullable, MissingRequiredField otherwise — instead of raising a confusing number-parse error. Aside from the truncation fix above, this is strictly more lenient: every previously-valid value parses identically.

Parse-error diagnostics keep the raw untrimmed value so users see what the document actually contained.

Docs: README gains a "Whitespace and missing values" section and now documents the non-nullable-Utf8 empty-string exception; FieldConfig rustdoc corrected (nullable exception; scale/offset apply to floats, as value = (value * scale) + offset).

Benchmarks within noise on both paths: the trim is two predictable compares for clean values, and the checked parse is what atoi() wraps internally plus one length compare.