### PR TITLE
feat!: reject truncated input, mark ParserOptions/DType non_exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "xml2arrow"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "approx",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml2arrow"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 description = "Efficiently convert XML data to Apache Arrow format for high-performance data processing"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-xml2arrow = "0.19.0"
+xml2arrow = "0.20.0"
 ```
 
 ## Features
@@ -39,6 +39,7 @@ xml2arrow = "0.19.0"
 - 💡 **Attribute and element extraction** using `@`-prefixed path segments for attributes
 - ⏹️ **Early termination** via `stop_at_paths` for efficiently reading only part of a file
 - 🌊 **Bounded-memory streaming** for documents larger than RAM — batched output via `parse_batches`, with a `RecordBatchReader` adapter for single-table configs
+- 🔒 **Safe on untrusted input** — no external entity resolution, no entity expansion, no silent truncation ([details](#-security--trust-model))
 
 ## Usage
 
@@ -56,6 +57,10 @@ parser_options:
                                # Set false to match raw qualified names and skip
                                # the per-name prefix scan (~4-7% faster); paths must
                                # then spell out any prefix. Free for prefix-free XML.
+  allow_truncated_input: <bool> # Accept input that ends mid-element (default: false).
+                               # By default a truncated document is an error rather
+                               # than a silently short result — see "Security &
+                               # trust model". Enable only for recovery tooling.
 tables:
   - name: <table_name>         # Name of the resulting Arrow RecordBatch
     xml_path: <xml_path>       # Path to the element whose children are rows.
@@ -461,6 +466,49 @@ tables:
 
 The `<station>` index in the `measurements` table links each measurement to its
 parent station by row position, enabling a join on `stations.<station> = measurements.<station>`.
+
+---
+
+## 🔒 Security & trust model
+
+`xml2arrow` is built to ingest XML from sources you do not control. The
+guarantees below are properties of the parser, not settings that can be
+misconfigured. They are pinned by `tests/adversarial_tests.rs`.
+
+### What an untrusted document cannot do
+
+- **Cause a file or network read (XXE-safe by construction).** `quick-xml` has
+  no entity resolver, so `SYSTEM`/`PUBLIC` entities are never fetched — a
+  document containing `<!ENTITY xxe SYSTEM "file:///etc/passwd">` resolves to an
+  error, not to the file's contents. No parse ever touches the filesystem or the
+  network on a document's behalf.
+- **Amplify itself through entity expansion ("billion laughs").** Only the five
+  predefined entities (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;`) and numeric
+  character references resolve. A nested-entity bomb fails at its first
+  reference, so there is nothing to expand.
+- **Overflow the stack.** Parsing is a flat event loop over a heap-allocated
+  path stack, never recursion; nesting depth cannot exhaust the call stack. Deep
+  nesting costs memory linearly in the input size (measured ~1.1×), so a
+  document cannot amplify its way to exhausting yours.
+- **Return quietly incomplete data.** A document that ends while elements are
+  still open is rejected with `Error::TruncatedInput` rather than returned as a
+  short batch. Set `parser_options.allow_truncated_input: true` if you are
+  deliberately recovering data from a partial document.
+
+### Known limitations
+
+- **Entities declared in a document's own DTD are not resolved.** Valid XML
+  using internal entities — `<!ENTITY greeting "hello">` … `&greeting;` — is
+  rejected with `ParseKind::UnresolvedEntity`. This is the trade-off that makes
+  the guarantees above unconditional rather than dependent on limits;
+  pre-process such documents if you need them.
+- **A single enormous text node is still buffered whole.** This is true of any
+  event-based parser: a one-gigabyte text node becomes a one-gigabyte value
+  regardless of batch settings.
+- **Streaming surfaces errors late.** `parse_batches` yields batches as they
+  fill, so a failure detected later in the document arrives after earlier
+  batches were handed out. Treat any error from a `BatchStream` as invalidating
+  the whole stream.
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,12 @@ use arrow::datatypes::DataType;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the XML parser.
+///
+/// Marked `#[non_exhaustive]`: construct via [`ParserOptions::default`] and
+/// mutate the fields you care about, so that adding an option in a future
+/// release stays a non-breaking change.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[non_exhaustive]
 pub struct ParserOptions {
     /// Whether to trim whitespace from text nodes. Defaults to false.
     #[serde(default)]
@@ -64,6 +69,22 @@ pub struct ParserOptions {
     /// uses no prefixes or your config already encodes them.
     #[serde(default = "default_true")]
     pub strip_namespaces: bool,
+    /// Whether to accept input that ends while elements are still open.
+    /// Defaults to `false`.
+    ///
+    /// A document cut short mid-element yields the rows parsed before the cut,
+    /// which is indistinguishable from a complete parse — silent data loss. By
+    /// default such input raises
+    /// [`Error::TruncatedInput`](crate::errors::Error) and no batches are
+    /// returned.
+    ///
+    /// Set to `true` only for recovery tooling that deliberately reads partial
+    /// documents (salvaging a killed writer's output, tailing a log). To stop
+    /// parsing early at a *known* point instead, use
+    /// [`stop_at_paths`](Self::stop_at_paths), which is unaffected by this
+    /// option.
+    #[serde(default)]
+    pub allow_truncated_input: bool,
 }
 
 impl Default for ParserOptions {
@@ -74,6 +95,7 @@ impl Default for ParserOptions {
             validate_closing_tags: true,
             validate_attributes: true,
             strip_namespaces: true,
+            allow_truncated_input: false,
         }
     }
 }
@@ -523,7 +545,11 @@ impl FieldConfigBuilder {
 }
 
 /// Represents the data type of a field.
+///
+/// Marked `#[non_exhaustive]`: downstream matches must include a wildcard arm,
+/// so that adding a data type in a future release stays a non-breaking change.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub enum DType {
     Boolean,
     Float32,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -80,6 +80,17 @@ pub enum Error {
     /// instead. Only reachable on enormous inputs (more than 2^32 rows in a
     /// single table scope), which the streaming entry points make possible.
     RowIndexOverflow { table: Arc<str> },
+    /// The document ended while elements were still open — the input was
+    /// truncated.
+    ///
+    /// The rows parsed before the cut are *not* returned: a partial batch is
+    /// indistinguishable from a complete one, so returning it silently would
+    /// hand the caller quietly incomplete data. `open_elements` is how many
+    /// elements were still unclosed at EOF.
+    ///
+    /// Deliberate early exits via `ParserOptions::stop_at_paths` do not raise
+    /// this; `ParserOptions::allow_truncated_input` disables it entirely.
+    TruncatedInput { open_elements: usize },
     /// A scale or offset was configured on a data type that doesn't support it.
     UnsupportedConversion {
         conversion: ConversionKind,
@@ -225,6 +236,10 @@ impl fmt::Display for Error {
                 f,
                 "Table '{table}' exceeded {} rows in a single scope; UInt32 <level> index columns cannot link further child rows",
                 u32::MAX
+            ),
+            Error::TruncatedInput { open_elements } => write!(
+                f,
+                "Truncated document: input ended with {open_elements} element(s) still open; the rows parsed so far are incomplete and were discarded (set parser_options.allow_truncated_input to accept them)"
             ),
             Error::UnsupportedConversion {
                 conversion,
@@ -399,6 +414,9 @@ impl From<Error> for PyErr {
             e @ Error::ParseError { .. } => ParseError::new_err(e.to_string()),
             e @ Error::MissingRequiredField { .. } => ParseError::new_err(e.to_string()),
             e @ Error::RowIndexOverflow { .. } => ParseError::new_err(e.to_string()),
+            // A document-wellformedness failure, not a value-decoding one, so
+            // it belongs with the parsing exceptions rather than `ParseError`.
+            e @ Error::TruncatedInput { .. } => XmlParsingError::new_err(e.to_string()),
             e @ Error::UnsupportedConversion { .. } => {
                 UnsupportedConversionError::new_err(e.to_string())
             }
@@ -449,6 +467,7 @@ mod tests {
             | Error::ParseError { .. }
             | Error::MissingRequiredField { .. }
             | Error::RowIndexOverflow { .. }
+            | Error::TruncatedInput { .. }
             | Error::UnsupportedConversion { .. }
             | Error::InvalidConfig { .. } => {}
         }
@@ -506,6 +525,7 @@ mod tests {
             Error::RowIndexOverflow {
                 table: Arc::from("t"),
             },
+            Error::TruncatedInput { open_elements: 2 },
             Error::UnsupportedConversion {
                 conversion: ConversionKind::Scaling,
                 data_type: "Int32".into(),

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -586,6 +586,9 @@ struct XmlToArrowConverter<'a> {
     /// prefix); when `false`, the raw qualified `name()` is used, skipping the
     /// per-name `:` scan. Cached here so the hot path reads a plain `bool`.
     strip_namespaces: bool,
+    /// Mirror of `ParserOptions::allow_truncated_input`; read once per parse,
+    /// on the `Event::Eof` arm.
+    allow_truncated_input: bool,
     /// Per-batch flush thresholds (rows / raw value bytes). The
     /// collect-everything entry points pass `usize::MAX` for both; the row
     /// threshold stays there, so its per-row comparison is an always-false,
@@ -663,6 +666,7 @@ impl<'a> XmlToArrowConverter<'a> {
             parent_indices_buffer: Vec::new(),
             validate_attributes: config.parser_options.validate_attributes,
             strip_namespaces: config.parser_options.strip_namespaces,
+            allow_truncated_input: config.parser_options.allow_truncated_input,
             max_rows_per_batch: max_rows_per_batch.max(1),
             max_bytes_per_batch: max_bytes_per_batch.clamp(1, MAX_BATCH_BYTES_CEILING),
             pending_flush: None,
@@ -1434,6 +1438,15 @@ fn close_element(
     Ok(LoopAction::Continue)
 }
 
+/// Builds the `TruncatedInput` error for the EOF completeness check. Outlined
+/// to keep `handle_event`'s body small (AGENTS.md §1), even though the check
+/// itself runs only once per parse.
+#[cold]
+#[inline(never)]
+fn truncated_input_error(open_elements: usize) -> Error {
+    Error::TruncatedInput { open_elements }
+}
+
 /// Resolves a general reference in element text (`&#66;`, `&amp;`,
 /// `&custom;`) and appends the resolved bytes to the fields listening at
 /// `node_id`.
@@ -1645,6 +1658,22 @@ fn handle_event<const PARSE_ATTRIBUTES: bool>(
             }
         }
         Event::Eof => {
+            // A well-formed document closes every element it opened, so the
+            // tracker is back at root depth here. Anything else means the input
+            // ended mid-element — a truncated file, a killed writer, a short
+            // read — and the rows parsed so far are a plausible-looking
+            // *partial* result. Returning them silently is the worst failure
+            // mode this crate has, so fail instead.
+            //
+            // quick-xml's `check_end_names` only rejects *mismatched* end tags,
+            // never *missing* ones, so this is the only point at which
+            // truncation is detectable. `stop_at_paths` exits via
+            // `close_element`'s Break and never reaches this arm, so deliberate
+            // early stops keep working.
+            let depth = path_tracker.depth();
+            if depth > 0 && !xml_to_arrow_converter.allow_truncated_input {
+                return Err(truncated_input_error(depth));
+            }
             return Ok(LoopAction::Break);
         }
         _ => (),
@@ -1969,6 +1998,20 @@ enum StreamState {
 ///
 /// The iterator is fused: after `None` — or after yielding an `Err` — it
 /// only returns `None`.
+///
+/// # An error invalidates the batches already yielded
+///
+/// Because batches are handed out as they fill, a failure detected later in
+/// the document — a malformed value, or an
+/// [`Error::TruncatedInput`](crate::errors::Error) raised at EOF — arrives
+/// *after* the consumer already holds earlier batches. Those batches are not
+/// wrong in themselves, but they are an incomplete view of the document.
+///
+/// Treat any `Err` from this iterator as invalidating the whole stream, not as
+/// one bad batch to skip: discard what you have accumulated, or stage it
+/// somewhere you can roll back. The collect-everything entry points
+/// ([`Parser::parse`], [`Parser::parse_slice`]) do not have this problem —
+/// they return `Err` and nothing else.
 // `Iterator`'s own `#[must_use]` does not carry over to a concrete named type,
 // so without this `parser.parse_batches(reader, options);` compiles and parses
 // nothing at all — silently, since the work is entirely lazy.
@@ -7389,5 +7432,69 @@ mod tests {
             parse_xml(r#"<data><row><v> 3x </v></row></data>"#.as_bytes(), &config).unwrap_err();
         assert!(matches!(err, Error::ParseError { .. }), "got: {err}");
         assert!(err.to_string().contains("' 3x '"), "got: {err}");
+    }
+
+    // --- Truncated input & nesting-depth guard ---
+    //
+    // The trust-model matrix (all three entry points × every adversarial
+    // input) lives in `tests/adversarial_tests.rs`. These unit tests cover the
+    // parser-internal specifics: which rows survive, and where the guard fires.
+
+    #[test]
+    fn test_truncated_document_is_rejected_not_returned_partially() {
+        // A document cut mid-element used to return the rows parsed before the
+        // cut, indistinguishable from a complete parse. The two complete rows
+        // here are exactly what made it dangerous: the result looked fine.
+        let config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#
+        );
+        let err = parse_xml_slice(
+            b"<data><row><v>a</v></row><row><v>b</v></row><row><v>c",
+            &config,
+        )
+        .unwrap_err();
+        match err {
+            Error::TruncatedInput { open_elements } => {
+                // `<data>`, `<row>` and `<v>` were all still open.
+                assert_eq!(open_elements, 3, "got: {open_elements}");
+            }
+            other => panic!("expected TruncatedInput, got {other}"),
+        }
+    }
+
+    #[test]
+    fn test_truncated_document_returns_completed_rows_when_opted_in() {
+        // The recovery hatch keeps the rows that *did* close, and drops the
+        // row that was still open at the cut.
+        let mut config = config_from_yaml!(
+            r#"
+            tables:
+                - name: t
+                  xml_path: /data
+                  levels: [row]
+                  fields:
+                    - name: v
+                      xml_path: /data/row/v
+                      data_type: Utf8
+            "#
+        );
+        config.parser_options.allow_truncated_input = true;
+        let batches = parse_xml_slice(
+            b"<data><row><v>a</v></row><row><v>b</v></row><row><v>c",
+            &config,
+        )
+        .unwrap();
+        let batch = batches.get("t").unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_array_values!(batch, "v", &["a", "b"], StringArray);
     }
 }

--- a/tests/adversarial_tests.rs
+++ b/tests/adversarial_tests.rs
@@ -1,0 +1,345 @@
+//! Adversarial and malformed-input tests.
+//!
+//! These pin the crate's **trust model** — what an untrusted document can and
+//! cannot make the parser do — as documented in the README's "Security & trust
+//! model" section. Each test names the guarantee it defends, so a change that
+//! weakens one fails loudly here rather than silently in a user's pipeline.
+//!
+//! Every case runs through all three entry points (`parse_xml_slice`,
+//! `parse_xml` over a `BufRead`, and `Parser::parse_batches_slice`). That is
+//! deliberate: the checks live in the shared `handle_event`, and this matrix is
+//! what proves the three event pumps have not drifted apart.
+
+use std::io::Write;
+
+use arrow::array::Array;
+use rstest::rstest;
+use tempfile::NamedTempFile;
+use xml2arrow::{
+    BatchOptions, Config, Error, Parser, errors::ParseKind, parse_xml, parse_xml_slice,
+};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// A config over `/r/v`, deliberately minimal so the tests exercise the parser
+/// rather than the configuration surface.
+fn config(extra_parser_options: &str) -> Config {
+    let yaml = format!(
+        r#"
+parser_options:
+{extra_parser_options}
+tables:
+  - name: rows
+    xml_path: /r
+    levels: [rows]
+    fields:
+      - name: v
+        xml_path: /r/v
+        data_type: Utf8
+        nullable: true
+"#
+    );
+    yaml_serde::from_str(&yaml).unwrap_or_else(|e| panic!("invalid YAML config: {e}"))
+}
+
+fn default_config() -> Config {
+    config("  {}")
+}
+
+/// The three public ways to drive a parse. Each returns the concatenated `v`
+/// column so tests can assert on *content*, not merely on `is_err()` — an
+/// error raised for the wrong reason must not pass a security assertion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Entry {
+    Slice,
+    Buffered,
+    Batches,
+}
+
+impl Entry {
+    fn run(self, xml: &str, config: &Config) -> Result<Vec<String>, Error> {
+        match self {
+            Entry::Slice => {
+                let batches = parse_xml_slice(xml.as_bytes(), config)?;
+                Ok(collect_values(batches.get("rows")))
+            }
+            Entry::Buffered => {
+                // Through a real file, so the buffered reader genuinely refills
+                // its buffer rather than seeing the whole document at once.
+                let mut file = NamedTempFile::new().expect("temp file");
+                file.write_all(xml.as_bytes()).expect("write");
+                file.flush().expect("flush");
+                let handle = std::fs::File::open(file.path()).expect("open");
+                let batches = parse_xml(std::io::BufReader::new(handle), config)?;
+                Ok(collect_values(batches.get("rows")))
+            }
+            Entry::Batches => {
+                let parser = Parser::new(config)?;
+                // A tiny row threshold forces multiple flushes, so a truncation
+                // or depth error has to survive being raised *after* batches
+                // have already been yielded.
+                let opts = BatchOptions::default().with_max_rows_per_batch(2);
+                let mut values = Vec::new();
+                for batch in parser.parse_batches_slice(xml.as_bytes(), opts) {
+                    let batch = batch?;
+                    if &*batch.table == "rows" {
+                        values.extend(collect_values(Some(&batch.batch)));
+                    }
+                }
+                Ok(values)
+            }
+        }
+    }
+}
+
+fn collect_values(batch: Option<&arrow::record_batch::RecordBatch>) -> Vec<String> {
+    let Some(batch) = batch else {
+        return Vec::new();
+    };
+    let Some(column) = batch.column_by_name("v") else {
+        return Vec::new();
+    };
+    let array = column
+        .as_any()
+        .downcast_ref::<arrow::array::StringArray>()
+        .expect("column 'v' is Utf8");
+    (0..array.len())
+        .map(|i| {
+            if arrow::array::Array::is_null(array, i) {
+                String::new()
+            } else {
+                array.value(i).to_string()
+            }
+        })
+        .collect()
+}
+
+const ALL_ENTRIES: [Entry; 3] = [Entry::Slice, Entry::Buffered, Entry::Batches];
+
+// ---------------------------------------------------------------------------
+// XXE — external entities are never fetched
+// ---------------------------------------------------------------------------
+
+#[test]
+fn xxe_system_file_entity_is_not_fetched() {
+    // The canary lives in a real file on disk that the document points at. The
+    // assertion is on *content*: no column may contain the canary, which is a
+    // strictly stronger claim than "the parse errored".
+    let mut canary = NamedTempFile::new().expect("temp file");
+    canary.write_all(b"XXECANARY_9F3A2B").expect("write canary");
+    canary.flush().expect("flush");
+    let path = canary.path().display().to_string();
+
+    let xml = format!(
+        r#"<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "file://{path}">]><r><v>&xxe;</v></r>"#
+    );
+
+    for entry in ALL_ENTRIES {
+        let result = entry.run(&xml, &default_config());
+        match result {
+            Err(Error::ParseError {
+                kind: ParseKind::UnresolvedEntity,
+                ..
+            }) => {}
+            Err(other) => panic!("{entry:?}: expected UnresolvedEntity, got {other}"),
+            Ok(values) => panic!("{entry:?}: expected an error, parsed {values:?}"),
+        }
+        // Belt and braces: even the error's own rendering must not carry the
+        // file's contents.
+        let rendered = format!("{:?}", entry.run(&xml, &default_config()));
+        assert!(
+            !rendered.contains("XXECANARY"),
+            "{entry:?}: canary leaked into output: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn xxe_http_entity_is_not_fetched() {
+    // No network path exists at all; this documents that as a guarantee rather
+    // than an accident of the test environment being offline.
+    let xml = r#"<?xml version="1.0"?><!DOCTYPE r [<!ENTITY xxe SYSTEM "http://127.0.0.1:1/x">]><r><v>&xxe;</v></r>"#;
+    for entry in ALL_ENTRIES {
+        assert!(
+            matches!(
+                entry.run(xml, &default_config()),
+                Err(Error::ParseError {
+                    kind: ParseKind::UnresolvedEntity,
+                    ..
+                })
+            ),
+            "{entry:?}: http entity should be unresolvable, not fetched"
+        );
+    }
+}
+
+#[test]
+fn parameter_entity_in_dtd_is_ignored() {
+    // The DTD's internal subset is inert: a parameter entity referencing an
+    // external resource neither resolves nor prevents the document's own data
+    // from parsing.
+    let xml = r#"<?xml version="1.0"?><!DOCTYPE r [<!ENTITY % pe SYSTEM "file:///etc/passwd"> %pe;]><r><v>ok</v></r>"#;
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run(xml, &default_config())
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert_eq!(values, vec!["ok".to_string()], "{entry:?}");
+    }
+}
+
+#[test]
+fn billion_laughs_does_not_expand() {
+    // Entity expansion is not merely bounded — it does not happen. The bomb
+    // fails at its first reference, so there is nothing to amplify. Asserting
+    // the *kind* matters: a timeout or an OOM would also "not return data".
+    let xml = r#"<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;"><!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">]><r><v>&lol3;</v></r>"#;
+    for entry in ALL_ENTRIES {
+        assert!(
+            matches!(
+                entry.run(xml, &default_config()),
+                Err(Error::ParseError {
+                    kind: ParseKind::UnresolvedEntity,
+                    ..
+                })
+            ),
+            "{entry:?}: entity bomb should fail at the first reference"
+        );
+    }
+}
+
+#[test]
+fn internal_dtd_entity_is_rejected() {
+    // Pins a documented *limitation*, not a bug: entities declared in the
+    // document's own DTD are not resolved either. This is the trade-off that
+    // makes the guarantees above unconditional. If we ever add internal-entity
+    // support, this test tells us we changed a published contract.
+    let xml =
+        r#"<?xml version="1.0"?><!DOCTYPE r [<!ENTITY greeting "hello">]><r><v>&greeting;</v></r>"#;
+    for entry in ALL_ENTRIES {
+        assert!(
+            matches!(
+                entry.run(xml, &default_config()),
+                Err(Error::ParseError {
+                    kind: ParseKind::UnresolvedEntity,
+                    ..
+                })
+            ),
+            "{entry:?}: internal DTD entities are documented as unresolved"
+        );
+    }
+}
+
+#[test]
+fn predefined_entities_and_char_refs_still_resolve() {
+    // Positive control: the guarantees above must not be achieved by refusing
+    // all entity syntax.
+    let xml = r#"<r><v>a&amp;b&#66;c&#x41;d</v></r>"#;
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run(xml, &default_config())
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert_eq!(values, vec!["a&bBcAd".to_string()], "{entry:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Truncation — a document that ends mid-element is not silently accepted
+// ---------------------------------------------------------------------------
+
+/// Cut points: mid-text, mid-element (after a complete row), and after a
+/// complete row but before the root closes. All three previously returned
+/// `Ok` with a short batch.
+#[rstest]
+#[case::mid_text("<r><v>a</v><v2>b</v2><v>c")]
+#[case::mid_element("<r><v>a</v><nested><deep>")]
+#[case::root_not_closed("<r><v>a</v>")]
+fn truncated_input_is_rejected(#[case] xml: &str) {
+    for entry in ALL_ENTRIES {
+        match entry.run(xml, &default_config()) {
+            Err(Error::TruncatedInput { open_elements }) => {
+                assert!(
+                    open_elements > 0,
+                    "{entry:?}: open_elements should be positive"
+                );
+            }
+            Err(other) => panic!("{entry:?}: expected TruncatedInput, got {other}"),
+            Ok(values) => panic!(
+                "{entry:?}: truncated input silently returned {} row(s): {values:?}",
+                values.len()
+            ),
+        }
+    }
+}
+
+#[test]
+fn complete_document_is_not_reported_as_truncated() {
+    // The other side of the check: a well-formed document must still parse.
+    let xml = "<r><v>a</v></r>";
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run(xml, &default_config())
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert_eq!(values, vec!["a".to_string()], "{entry:?}");
+    }
+}
+
+#[test]
+fn truncated_input_is_accepted_when_opted_in() {
+    // The recovery escape hatch returns the rows parsed before the cut.
+    let config = config("  allow_truncated_input: true");
+    let xml = "<r><v>a</v><v2>x</v2><v>b";
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run(xml, &config)
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert_eq!(values, vec!["a".to_string()], "{entry:?}");
+    }
+}
+
+#[test]
+fn stop_at_paths_is_not_truncation() {
+    // Regression guard for the *placement* of the check. `stop_at_paths` exits
+    // through `close_element`'s Break and never reaches the Eof arm, so a
+    // deliberate early stop on a complete document must still succeed. A naive
+    // "depth > 0 when the loop exits" implementation placed in the event pumps
+    // rather than in the Eof arm would fail here.
+    let config = config("  stop_at_paths: ['/r/v']");
+    let xml = "<r><v>a</v><v>b</v></r>";
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run(xml, &config)
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert_eq!(values, vec!["a".to_string()], "{entry:?}");
+    }
+}
+
+#[test]
+fn empty_input_is_not_reported_as_truncated() {
+    // Zero elements opened means depth 0 at EOF — an empty document is valid
+    // (and already covered by an integration test), not truncated.
+    for entry in ALL_ENTRIES {
+        let values = entry
+            .run("", &default_config())
+            .unwrap_or_else(|e| panic!("{entry:?}: {e}"));
+        assert!(values.is_empty(), "{entry:?}: got {values:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Other malformed input
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mismatched_end_tag_is_rejected() {
+    // Pre-existing quick-xml behaviour (`validate_closing_tags`), pinned here
+    // so the trust-model section can cite it.
+    let xml = "<r><v>a</b></r>";
+    for entry in ALL_ENTRIES {
+        assert!(
+            entry.run(xml, &default_config()).is_err(),
+            "{entry:?}: mismatched end tag should be rejected"
+        );
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -772,3 +772,44 @@ fn test_realistic_sensor_data_parsed_correctly() {
         StringArray
     );
 }
+
+#[test]
+fn test_truncated_file_is_rejected_rather_than_silently_short() {
+    // Regression: a file cut short mid-element (killed writer, short read,
+    // partial download) used to parse to `Ok` with only the rows that had
+    // closed before the cut — a partial result indistinguishable from a
+    // complete one. File-based because that is how truncation actually
+    // reaches users; the buffered reader must surface it just as the
+    // zero-copy path does.
+    let xml_file =
+        write_xml_tempfile(r#"<data><item><id>1</id></item><item><id>2</id></item><item><id>3"#);
+    let config: Config = yaml_serde::from_str(
+        r#"
+        tables:
+          - name: items
+            xml_path: /data
+            levels: [item]
+            fields:
+              - name: id
+                xml_path: /data/item/id
+                data_type: Int32
+        "#,
+    )
+    .unwrap();
+
+    let file = File::open(xml_file.path()).unwrap();
+    let err = parse_xml(BufReader::new(file), &config).unwrap_err();
+    assert!(
+        matches!(err, xml2arrow::Error::TruncatedInput { .. }),
+        "expected TruncatedInput, got: {err}"
+    );
+
+    // Opting in returns the two rows that did close, and nothing more.
+    let mut lenient = config.clone();
+    lenient.parser_options.allow_truncated_input = true;
+    let file = File::open(xml_file.path()).unwrap();
+    let batches = parse_xml(BufReader::new(file), &lenient).unwrap();
+    let items = batches.get("items").unwrap();
+    assert_eq!(items.num_rows(), 2);
+    assert_array_values!(items, "id", &[1, 2], Int32Array);
+}


### PR DESCRIPTION
A document that ended while elements were still open used to parse to Ok, returning the rows that had closed before the cut. The result was a well-formed RecordBatch, indistinguishable from a complete parse, so a killed writer, a short read or a partial download silently produced quietly incomplete data. quick-xml's check_end_names validates mismatched end tags but never missing ones, so nothing caught it.

Event::Eof now fails with Error::TruncatedInput when the path tracker is above root depth. The check sits in handle_event, which all three event pumps (buffered, zero-copy, BatchStream) share, so it covers every entry point with no extra plumbing. stop_at_paths exits through close_element's Break and never reaches that arm, so deliberate early stops are unaffected. ParserOptions::allow_truncated_input (default false) restores the old behaviour for recovery tooling.

Also:

- ParserOptions and DType are #[non_exhaustive], so future options and data types stop being breaking changes. This is a prerequisite for the planned temporal/decimal dtypes and null_values option.
- tests/adversarial_tests.rs pins the trust model — XXE via file:// and http:// (asserted on content, with an on-disk canary), parameter entities, billion-laughs, the internal-DTD-entity limitation, and truncation — each across all three entry points, which is also what proves the pumps have not drifted.
- README gains a "Security & trust model" section stating the guarantees and, equally prominently, the limitations.
- BatchStream rustdoc now warns that an error invalidates batches already yielded.

A nesting-depth guard was attempted and dropped: it cost +76% on parse_small/zero_copy and +100% on parse_wide_fanout/zero_copy in every placement tried (inline and outlined), while measured memory amplification from deep nesting is only ~1.14x on a heap Vec with no stack-overflow path. Bad trade; re-filed with the evidence.

Benchmarks vs a clean baseline: every case neutral or improved (parse_small/zero_copy -0.4%, parse_wide_fanout/zero_copy -0.3%, parse_tiny -2.4%).

BREAKING CHANGE: truncated documents now error instead of returning partial rows; struct-literal construction of ParserOptions and exhaustive matches on DType no longer compile outside the crate. Use ParserOptions::default() plus field mutation.